### PR TITLE
Add LAN8742A TCP client example

### DIFF
--- a/DMM/Core/Inc/tcp_client.h
+++ b/DMM/Core/Inc/tcp_client.h
@@ -1,0 +1,10 @@
+#ifndef TCP_CLIENT_H
+#define TCP_CLIENT_H
+
+#include <stddef.h>
+#include "lwip/tcp.h"
+
+void tcp_client_init(void);
+void tcp_client_send(const char *data, size_t len);
+
+#endif /* TCP_CLIENT_H */

--- a/DMM/Core/Src/main.c
+++ b/DMM/Core/Src/main.c
@@ -31,6 +31,7 @@
 #include "bsp_AD7190.h"
 #include "bsp_debug_usart.h"
 #include "lcd.h"
+#include "tcp_client.h"
 /* USER CODE END Includes */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -138,6 +139,7 @@ int main(void)
   //MX_UART4_Init();
   MX_DEBUG_USART_Init();
   MX_SPI1_Init();
+  tcp_client_init();
   /* USER CODE BEGIN 2 */
   if(AD7190_Init()==0)
   {

--- a/DMM/Core/Src/tcp_client.c
+++ b/DMM/Core/Src/tcp_client.c
@@ -1,0 +1,35 @@
+#include "tcp_client.h"
+#include "lwip/err.h"
+#include "lwip/init.h"
+#include "lwip/ip_addr.h"
+#include <string.h>
+
+static struct tcp_pcb *client_pcb;
+
+static err_t tcp_client_connected(void *arg, struct tcp_pcb *tpcb, err_t err)
+{
+    const char hello[] = "Hello from STM32F407";
+    tcp_write(tpcb, hello, strlen(hello), TCP_WRITE_FLAG_COPY);
+    tcp_output(tpcb);
+    return ERR_OK;
+}
+
+void tcp_client_init(void)
+{
+    ip_addr_t server_ip;
+    IP_ADDR4(&server_ip, 192, 168, 1, 100); /* adjust server IP */
+    client_pcb = tcp_new();
+    if (client_pcb != NULL)
+    {
+        tcp_connect(client_pcb, &server_ip, 5000, tcp_client_connected);
+    }
+}
+
+void tcp_client_send(const char *data, size_t len)
+{
+    if (client_pcb != NULL && data != NULL && len > 0)
+    {
+        tcp_write(client_pcb, data, len, TCP_WRITE_FLAG_COPY);
+        tcp_output(client_pcb);
+    }
+}


### PR DESCRIPTION
## Summary
- add lightweight LwIP-based TCP client module
- wire TCP client initialization into system startup

## Testing
- `make -C DMM/Debug` *(fails: usart/subdir.mk:18: *** target pattern contains no '%' )*

------
https://chatgpt.com/codex/tasks/task_e_6895b107fd54832c807f64e854937903