### PR TITLE
Align ADC trigger with TIMER0 PWM midpoint

### DIFF
--- a/0917/APP/src/main.c
+++ b/0917/APP/src/main.c
@@ -1,22 +1,22 @@
 
 /*********************************************************************************************************
-* Ä£¿éÃû³Æ£ºmain.c
-* Õª    Òª£º
-* µ±Ç°°æ±¾£º1.0.0
-* ×÷    Õß£ºRengar
-* Íê³ÉÈÕÆÚ£º2025Äê09ÔÂ24ÈÕ  
-* ÄÚ    Èİ£º
-* ×¢    Òâ£º                                                                  
+* æ¨¡å—åç§°ï¼šmain.c
+* æ‘˜    è¦ï¼š
+* å½“å‰ç‰ˆæœ¬ï¼š1.0.0
+* ä½œ    è€…ï¼šRengar
+* å®Œæˆæ—¥æœŸï¼š2025å¹´09æœˆ24æ—¥  
+* å†…    å®¹ï¼š
+* æ³¨    æ„ï¼š                                                                  
 **********************************************************************************************************
-* È¡´ú°æ±¾£º
-* ×÷    Õß£º
-* Íê³ÉÈÕÆÚ£º
-* ĞŞ¸ÄÄÚÈİ£º
-* ĞŞ¸ÄÎÄ¼ş£º
+* å–ä»£ç‰ˆæœ¬ï¼š
+* ä½œ    è€…ï¼š
+* å®Œæˆæ—¥æœŸï¼š
+* ä¿®æ”¹å†…å®¹ï¼š
+* ä¿®æ”¹æ–‡ä»¶ï¼š
 *********************************************************************************************************/
 
 /*********************************************************************************************************
-*                                              °üº¬Í·ÎÄ¼ş
+*                                              åŒ…å«å¤´æ–‡ä»¶
 *********************************************************************************************************/
 #include "main.h"
 #include <math.h>
@@ -30,7 +30,7 @@
 #include "llc_open_loop.h"
 #include "pfc_control.h"
 /*********************************************************************************************************
-*                                              Ä£¿é²âÊÔÅäÖÃ
+*                                              æ¨¡å—æµ‹è¯•é…ç½®
 *********************************************************************************************************/
 #ifndef ENABLE_ADC_TEST
 #define ENABLE_ADC_TEST              0
@@ -70,14 +70,14 @@
 #define LLC_TEST_TOGGLE_PERIOD_MS     5000U
 #endif
 /*********************************************************************************************************
-*                                              ºê¶¨Òå
+*                                              å®å®šä¹‰
 *********************************************************************************************************/
 
 #define LLC_USE_OPEN_LOOP 1
 
 #define Bus_Adj 0
 /*********************************************************************************************************
-*                                              Ã¶¾Ù½á¹¹Ìå
+*                                              æšä¸¾ç»“æ„ä½“
 *********************************************************************************************************/
 
 enum{
@@ -94,8 +94,8 @@ typedef struct
 {
 	pfc_state_t state;
 	uint32_t entry_ms;
-	uint32_t vbus_ok_since_ms; //±íÊ¾×ÜÏßµçÑ¹×Ô´Ó±äÎªokºóµÄÊ±¼äµã£¬Èç¹ûÎ´ÎÈ¶¨Í¨³£Ô¼¶¨Îª0
-	uint32_t dropout_since_ms; //±íÊ¾·¢Éúµôµç/Ê§ÎÈÊ±¼äµÄÊ±¼äµã£¬ÓÃÀ´ÅĞ¶ÏÊÇ·ñĞèÒª½øÈë¼õÔØ»òÕßÖØÊÔÂß¼­
+	uint32_t vbus_ok_since_ms; //è¡¨ç¤ºæ€»çº¿ç”µå‹è‡ªä»å˜ä¸ºokåçš„æ—¶é—´ç‚¹ï¼Œå¦‚æœæœªç¨³å®šé€šå¸¸çº¦å®šä¸º0
+	uint32_t dropout_since_ms; //è¡¨ç¤ºå‘ç”Ÿæ‰ç”µ/å¤±ç¨³æ—¶é—´çš„æ—¶é—´ç‚¹ï¼Œç”¨æ¥åˆ¤æ–­æ˜¯å¦éœ€è¦è¿›å…¥å‡è½½æˆ–è€…é‡è¯•é€»è¾‘
 	bool enable_cmd;
 } pfc_app_ctx_t;
 
@@ -108,7 +108,7 @@ typedef struct
 	float start_duty;
 	float target_duty;
 	
-// ÔËĞĞÊ±¼ÆËãµÃµ½µÄ°²È«ÉÏÏÂÏŞ
+// è¿è¡Œæ—¶è®¡ç®—å¾—åˆ°çš„å®‰å…¨ä¸Šä¸‹é™
 	float    duty_min_safe;
 	float    duty_max_safe;
 } llc_softstart_ctx_t;
@@ -173,7 +173,7 @@ static inline void module_tests_init(void) { }
 static inline void module_tests_tick_1khz(float vbus_v) { (void)vbus_v; }
 #endif
 /*********************************************************************************************************
-*                                              ÄÚ²¿±äÁ¿¶¨Òå
+*                                              å†…éƒ¨å˜é‡å®šä¹‰
 *********************************************************************************************************/
 static float s_pfc_bus_v = 0.0f;
 static bool s_pfc_hw_enabled = false;
@@ -201,14 +201,14 @@ static const llc_open_loop_segment_t s_llc_open_loop_profile[] = {
 volatile uint32_t g_ms=0;
 static volatile uint32_t s_control_tick_pending = 0U;
 
-/* ¿ØÖÆÑ­»·²ÎÊı£¨1 kHz£© */
+/* æ§åˆ¶å¾ªç¯å‚æ•°ï¼ˆ1 kHzï¼‰ */
 #define CONTROL_LOOP_HZ            (1000U)
 #define CONTROL_LOOP_DT_S          (1.0f / (float)CONTROL_LOOP_HZ)
-/* Ö÷Ñ­»·Ò»´Î×î¶à´¦ÀíµÄ tick£¬³¬¹ı½«¼ÆÊıÎª¶ªÆú£¨±ÜÃâÖ÷Ñ­»·³¤Ê±¼äÕ¼ÓÃ£© */
+/* ä¸»å¾ªç¯ä¸€æ¬¡æœ€å¤šå¤„ç†çš„ tickï¼Œè¶…è¿‡å°†è®¡æ•°ä¸ºä¸¢å¼ƒï¼ˆé¿å…ä¸»å¾ªç¯é•¿æ—¶é—´å ç”¨ï¼‰ */
 #define MAX_TICKS_PER_LOOP         (5U)
-static volatile uint32_t s_tick_drop_count = 0U; /* ±»¶ªÆúµÄ tick ¼ÆÊı */
+static volatile uint32_t s_tick_drop_count = 0U; /* è¢«ä¸¢å¼ƒçš„ tick è®¡æ•° */
 /*********************************************************************************************************
-*                                              ÄÚ²¿º¯ÊıÉùÃ÷
+*                                              å†…éƒ¨å‡½æ•°å£°æ˜
 *********************************************************************************************************/
 static void llc_softstart_reset(void);
 static void llc_softstart_begin(float target_duty);
@@ -223,7 +223,7 @@ static void pfc_hw_set_relay(bool closed);
 void systick_1ms_init(void);
 
 /*********************************************************************************************************
-*                                              ÄÚ²¿º¯ÊıÊµÏÖ
+*                                              å†…éƒ¨å‡½æ•°å®ç°
 *********************************************************************************************************/
 void systick_config(void)
 {
@@ -240,20 +240,20 @@ void systick_1ms_init(void){
 		SystemCoreClockUpdate();    
      uint32_t reload  = SystemCoreClock / 1000U;
 	  if (reload == 0U || reload > SysTick_LOAD_RELOAD_Msk) {
-                                           // Ê§°Ü£ºÆµÂÊÒì³£»ò³¬³ö24Î»
+                                           // å¤±è´¥ï¼šé¢‘ç‡å¼‚å¸¸æˆ–è¶…å‡º24ä½
     }
-		reload -= 1U; //µ÷ÕûÖØÔØÖµ£¬È·±£¶¨Ê±Æ÷ĞĞÎª·ûºÏÔ¤ÆÚ¡£
+		reload -= 1U; //è°ƒæ•´é‡è½½å€¼ï¼Œç¡®ä¿å®šæ—¶å™¨è¡Œä¸ºç¬¦åˆé¢„æœŸã€‚
 		if (reload > SysTick_LOAD_RELOAD_Msk) {
 			reload = SysTick_LOAD_RELOAD_Msk;
 		}
 		
-		SysTick->CTRL = 0U;  //ÏÈ½ûÓÃ SysTick¡£
-		SysTick->LOAD = reload; //ÉèÖÃÖØÔØÖµ¡£
-		SysTick->VAL  = 0U; //Çå³ıµ±Ç°¼ÆÊıÖµ¡£
+		SysTick->CTRL = 0U;  //å…ˆç¦ç”¨ SysTickã€‚
+		SysTick->LOAD = reload; //è®¾ç½®é‡è½½å€¼ã€‚
+		SysTick->VAL  = 0U; //æ¸…é™¤å½“å‰è®¡æ•°å€¼ã€‚
     NVIC_SetPriority(SysTick_IRQn, 0x0F);
-		//ÉèÖÃ SysTick µÄÊ±ÖÓÔ´¡£Èç¹û¸ÃÎ»±»ÖÃ 1£¬±íÊ¾Ê¹ÓÃ´¦ÀíÆ÷Ê±ÖÓ£¨HCLK£©£»Èç¹ûÎª 0£¬±íÊ¾Ê¹ÓÃ HCLK µÄ 8 ·ÖÆµ¡£
-		//¿ØÖÆ SysTick ÖĞ¶ÏµÄÆôÓÃ¡£Èç¹û¸ÃÎ»±»ÖÃ 1£¬±íÊ¾ÔÊĞí SysTick ¶¨Ê±Æ÷ÔÚ¼ÆÊıµ½ 0 Ê±´¥·¢ÖĞ¶Ï¡£
-		//¿ØÖÆ SysTick ¶¨Ê±Æ÷µÄÆôÓÃ¡£Èç¹û¸ÃÎ»±»ÖÃ 1£¬±íÊ¾Æô¶¯¶¨Ê±Æ÷¼ÆÊı¡£
+		//è®¾ç½® SysTick çš„æ—¶é’Ÿæºã€‚å¦‚æœè¯¥ä½è¢«ç½® 1ï¼Œè¡¨ç¤ºä½¿ç”¨å¤„ç†å™¨æ—¶é’Ÿï¼ˆHCLKï¼‰ï¼›å¦‚æœä¸º 0ï¼Œè¡¨ç¤ºä½¿ç”¨ HCLK çš„ 8 åˆ†é¢‘ã€‚
+		//æ§åˆ¶ SysTick ä¸­æ–­çš„å¯ç”¨ã€‚å¦‚æœè¯¥ä½è¢«ç½® 1ï¼Œè¡¨ç¤ºå…è®¸ SysTick å®šæ—¶å™¨åœ¨è®¡æ•°åˆ° 0 æ—¶è§¦å‘ä¸­æ–­ã€‚
+		//æ§åˆ¶ SysTick å®šæ—¶å™¨çš„å¯ç”¨ã€‚å¦‚æœè¯¥ä½è¢«ç½® 1ï¼Œè¡¨ç¤ºå¯åŠ¨å®šæ—¶å™¨è®¡æ•°ã€‚
 		SysTick->CTRL = SysTick_CTRL_CLKSOURCE_Msk |  
 								SysTick_CTRL_TICKINT_Msk   |
 								SysTick_CTRL_ENABLE_Msk;
@@ -264,13 +264,13 @@ static inline float conv_adc_to_v_div(uint16_t raw, float rtop, float rbot){
     return v * (rtop + rbot) / rbot;
 }
 
-//È¥Æ«ÖÃ
-//float v_net = v_adc - v_zero;               // È¥Æ«ÖÃ
-//return v_net / (ISHUNT_OHM * IAMP_GAIN);    // µ¥Î»£º°²Åà
-//v_zero¡Ö0.17V
+//å»åç½®
+//float v_net = v_adc - v_zero;               // å»åç½®
+//return v_net / (ISHUNT_OHM * IAMP_GAIN);    // å•ä½ï¼šå®‰åŸ¹
+//v_zeroâ‰ˆ0.17V
 static inline float conv_adc_to_i(uint16_t raw){
     float v = (raw * VREF_ADC) / 4095.0f;
-		float v1 = v - 0.17;              // È¥Æ«ÖÃ
+		float v1 = v - 0.17;              // å»åç½®
     return v1 / (ISHUNT_OHM * IAMP_GAIN);
 }
 static inline float f_absf(float x){ return x < 0 ? -x : x; }
@@ -282,24 +282,24 @@ static inline float f_clampf(float x,float lo,float hi)
 #if LLC_SOFTSTART_ENABLE
 
 
-/* ¸ù¾İµ±Ç°ÖÜÆÚ/ËÀÇø£¬¼ÆËã¡°ÓĞĞ§Õ¼¿Õ°²È«´°¡± */
+/* æ ¹æ®å½“å‰å‘¨æœŸ/æ­»åŒºï¼Œè®¡ç®—â€œæœ‰æ•ˆå ç©ºå®‰å…¨çª—â€ */
 static void ss_update_safe_window(void)
 {
 	  uint32_t per_ns = llc_pwm_get_period_ns();
     uint32_t dt_ns  = llc_pwm_get_deadtime_ns();
 	  float guard = 0.0f;
     if (per_ns > 0U) {
-        /* »¥²¹Á½ÑØ¶¼²åËÀÇø£º±£ÊØÈ¡ 2*deadtime */
+        /* äº’è¡¥ä¸¤æ²¿éƒ½æ’æ­»åŒºï¼šä¿å®ˆå– 2*deadtime */
         guard = (2.0f * (float)dt_ns) / (float)per_ns;  // 0~1
     }
-		guard += LLC_SOFTSTART_EXTRA_MARGIN; // ¾­ÑéÓàÁ¿
+		guard += LLC_SOFTSTART_EXTRA_MARGIN; // ç»éªŒä½™é‡
 
-    /* ÏÂÏŞ²»³¬¹ı 0.49£¬ÉÏÏŞ²»µÍÓÚ 0.51£¬±ÜÃâ¿¿½ü 50% ¸½½üÅ¼·¢Ö±Í¨/ÎŞĞ§Âö¿í */
+    /* ä¸‹é™ä¸è¶…è¿‡ 0.49ï¼Œä¸Šé™ä¸ä½äº 0.51ï¼Œé¿å…é è¿‘ 50% é™„è¿‘å¶å‘ç›´é€š/æ— æ•ˆè„‰å®½ */
     s_llc_softstart.duty_min_safe = f_clampf(guard, 0.0f, 0.49f);
     s_llc_softstart.duty_max_safe = f_clampf(1.0f - guard,  0.51f, 0.99f);
 }
 
-/* ÓàÏÒ S ÇúÏß£º0¡ú1 */
+/* ä½™å¼¦ S æ›²çº¿ï¼š0â†’1 */
 static inline float ease_cos(float t)
 {
     if (t <= 0.f) return 0.f;
@@ -314,7 +314,7 @@ static void ss_apply(float duty)
 }
 
 
-/* Ö¸ÊıÇúÏß£º0¡ú1 */
+/* æŒ‡æ•°æ›²çº¿ï¼š0â†’1 */
 static inline float ease_exp(float t, float k)
 {
     if (t <= 0.f) return 0.f;
@@ -371,7 +371,7 @@ void llc_softstart_abort(void)
 {
     s_llc_softstart.active = false;
     s_llc_softstart.pause = false;
-    ss_update_safe_window(); // ÒÔ·ÀÆÚ¼ä¸Ä¹ıÆµÂÊ/ËÀÇø
+    ss_update_safe_window(); // ä»¥é˜²æœŸé—´æ”¹è¿‡é¢‘ç‡/æ­»åŒº
     ss_apply(f_clampf(LLC_SOFTSTART_FAILSAFE_DUTY, 0.0f, 0.99f));
 }
 
@@ -380,7 +380,7 @@ static void llc_softstart_tick(void)
     if (!s_llc_softstart.active) 
 			return;
 
-    /* ÓÃÄãÏîÄ¿ÒÑÓĞµÄ¹ÊÕÏÅĞ¾İ */
+    /* ç”¨ä½ é¡¹ç›®å·²æœ‰çš„æ•…éšœåˆ¤æ® */
     if (protect_fault_latched() || protect_fault_active_hw()) {
         llc_softstart_abort();
         return;
@@ -397,14 +397,14 @@ static void llc_softstart_tick(void)
 		float progress = (s_llc_softstart.duration_ms > 0U) ? ((float)elapsed / (float)s_llc_softstart.duration_ms) : 1.0f;
 
 		
-		 /* ½«ÏßĞÔ»»³É S ÇúÏß£¨ÈçĞèÏßĞÔ£¬°Ñ ease ¸Ä³É progress£© */
+		 /* å°†çº¿æ€§æ¢æˆ S æ›²çº¿ï¼ˆå¦‚éœ€çº¿æ€§ï¼ŒæŠŠ ease æ”¹æˆ progressï¼‰ */
 #if defined(LLC_SOFTSTART_USE_COSINE_EASE) && (LLC_SOFTSTART_USE_COSINE_EASE)
     float k = ease_cos(progress);
 #else
     float k = ease_exp(progress, 3.0f);
 #endif
 		
-		//Ê¹ÓÃÏßĞÔ²åÖµ¹«Ê½¼ÆËãµ±Ç°Õ¼¿Õ±È
+		//ä½¿ç”¨çº¿æ€§æ’å€¼å…¬å¼è®¡ç®—å½“å‰å ç©ºæ¯”
 		float duty = s_llc_softstart.start_duty +
 								 (s_llc_softstart.target_duty - s_llc_softstart.start_duty) * progress;
 		ss_apply(duty);
@@ -473,7 +473,7 @@ static void module_tests_tick_1khz(float vbus_v)
 #endif
 
 #if ENABLE_PWM_TEST
-//Í¨¹ıÏàÎ»µİÔöºÍ·Ö¶Î¼ÆËã£¬ÊµÏÖÁËÕ¼¿Õ±ÈµÄÆ½»¬±ä»¯¡£
+//é€šè¿‡ç›¸ä½é€’å¢å’Œåˆ†æ®µè®¡ç®—ï¼Œå®ç°äº†å ç©ºæ¯”çš„å¹³æ»‘å˜åŒ–ã€‚
     uint32_t phase = (s_module_tests.pwm.sweep_phase + 1U) % PWM_TEST_SWEEP_PERIOD_MS;
     s_module_tests.pwm.sweep_phase = phase;
     uint32_t half = PWM_TEST_SWEEP_PERIOD_MS / 2U;
@@ -616,7 +616,7 @@ static void pfc_state_enter(pfc_state_t next)
 
 			break;
 		case PFC_ST_READY:
-			// µ½ÕâÒ»²½²ÅºÏÉÏ¼ÌµçÆ÷
+			// åˆ°è¿™ä¸€æ­¥æ‰åˆä¸Šç»§ç”µå™¨
 			pfc_hw_set_enable(true);
 			//pfc_hw_set_relay(true);
 			s_pfc_app.vbus_ok_since_ms = g_ms;
@@ -641,7 +641,7 @@ void pfc_app_init()
 	pfc_hw_set_enable(false);
 	//pfc_hw_set_relay(false);
 }
-//¸Ãº¯ÊıµÄÄ¿µÄÊÇÔÚÆô¶¯Ä³ÖÖÇëÇóÊ±£¬È·±£ÏµÍ³×´Ì¬ÕıÈ·£¬²¢¼ÇÂ¼ÇëÇóµÄÆğÊ¼Ê±¼ä£¨Èç¹ûÏµÍ³µ±Ç°²»´¦ÓÚ¿ÕÏĞ×´Ì¬£©¡£
+//è¯¥å‡½æ•°çš„ç›®çš„æ˜¯åœ¨å¯åŠ¨æŸç§è¯·æ±‚æ—¶ï¼Œç¡®ä¿ç³»ç»ŸçŠ¶æ€æ­£ç¡®ï¼Œå¹¶è®°å½•è¯·æ±‚çš„èµ·å§‹æ—¶é—´ï¼ˆå¦‚æœç³»ç»Ÿå½“å‰ä¸å¤„äºç©ºé—²çŠ¶æ€ï¼‰ã€‚
 void pfc_app_request_start(void)
 {
 	s_pfc_app.enable_cmd = true;
@@ -660,20 +660,20 @@ void pfc_app_force_off()
 	}
 }
 /*********************************************************************************************************
-* º¯ÊıÃû³Æ£ºpfc_app_tick_1khz
-* º¯Êı¹¦ÄÜ£ºÆäÖ÷ÒªÄ¿µÄÊÇ¸ù¾İÊäÈëµçÑ¹£¨ vbus_v £©ºÍÏµÍ³×´Ì¬£¨Èç¹ÊÕÏ¡¢Ê¹ÄÜÃüÁîµÈ£©¶¯Ì¬µ÷Õû PFC µÄ¹¤×÷×´Ì¬£¬
-	È·±£ÏµÍ³ÔÚ°²È«¡¢¸ßĞ§µÄ×´Ì¬ÏÂÔËĞĞ¡£
-* ÊäÈë²ÎÊı£ºvbus_v
-* Êä³ö²ÎÊı£ºvoid
-* ·µ »Ø Öµ£ºvoid
-* ´´½¨ÈÕÆÚ£º2025Äê10ÔÂ09ÈÕ
-* ×¢    Òâ£ºÓĞÆô¶¯ÑÓÊ±¡¢´ï±ê±£³Ö¡¢³ÙÖÍ¡¢READY Ïû¶¶ºÍ³äµç³¬Ê±ÎåµÀ±£ÕÏ£¬ÏÖ³¡±íÏÖ»á¸ü¡°ÎÈÇÒ¿ÉÔ¤ÆÚ
+* å‡½æ•°åç§°ï¼špfc_app_tick_1khz
+* å‡½æ•°åŠŸèƒ½ï¼šå…¶ä¸»è¦ç›®çš„æ˜¯æ ¹æ®è¾“å…¥ç”µå‹ï¼ˆ vbus_v ï¼‰å’Œç³»ç»ŸçŠ¶æ€ï¼ˆå¦‚æ•…éšœã€ä½¿èƒ½å‘½ä»¤ç­‰ï¼‰åŠ¨æ€è°ƒæ•´ PFC çš„å·¥ä½œçŠ¶æ€ï¼Œ
+	ç¡®ä¿ç³»ç»Ÿåœ¨å®‰å…¨ã€é«˜æ•ˆçš„çŠ¶æ€ä¸‹è¿è¡Œã€‚
+* è¾“å…¥å‚æ•°ï¼švbus_v
+* è¾“å‡ºå‚æ•°ï¼švoid
+* è¿” å› å€¼ï¼švoid
+* åˆ›å»ºæ—¥æœŸï¼š2025å¹´10æœˆ09æ—¥
+* æ³¨    æ„ï¼šæœ‰å¯åŠ¨å»¶æ—¶ã€è¾¾æ ‡ä¿æŒã€è¿Ÿæ»ã€READY æ¶ˆæŠ–å’Œå……ç”µè¶…æ—¶äº”é“ä¿éšœï¼Œç°åœºè¡¨ç°ä¼šæ›´â€œç¨³ä¸”å¯é¢„æœŸ
 *********************************************************************************************************/
 void pfc_app_tick_1khz(float vbus_v)
 {
 	s_pfc_bus_v = vbus_v;
 	bool fault_active = protect_fault_latched()||protect_fault_active_hw();
-	//ÅÅ³ı¹ÊÕÏ×´Ì¬
+	//æ’é™¤æ•…éšœçŠ¶æ€
 	if(fault_active && s_pfc_app.state != PFC_ST_FAULT)
 	{
 		pfc_state_enter(PFC_ST_FAULT);
@@ -694,7 +694,7 @@ void pfc_app_tick_1khz(float vbus_v)
 			}
 			if(!s_pfc_hw_enabled)
 			{
-				//ÓÃÊ¾²¨Æ÷²âÁ¿´ÓÊ¹ÄÜĞÅºÅ£¨ pfc_hw_set_enable(true) £©µ½Êä³öµçÑ¹ÎÈ¶¨µÄÊµ¼ÊÊ±¼ä,½«ÑÓÊ±ÉèÎªÊµ²âÊ±¼äµÄ 1.2-1.5±¶ ÒÔÁôÓàÁ¿¡£
+				//ç”¨ç¤ºæ³¢å™¨æµ‹é‡ä»ä½¿èƒ½ä¿¡å·ï¼ˆ pfc_hw_set_enable(true) ï¼‰åˆ°è¾“å‡ºç”µå‹ç¨³å®šçš„å®é™…æ—¶é—´,å°†å»¶æ—¶è®¾ä¸ºå®æµ‹æ—¶é—´çš„ 1.2-1.5å€ ä»¥ç•™ä½™é‡ã€‚
 				if((uint32_t)(g_ms - s_pfc_app.entry_ms)<PFC_STARTUP_DELAY_MS)
 				{
 					break;
@@ -703,7 +703,7 @@ void pfc_app_tick_1khz(float vbus_v)
 			}
 			
 			
-			//ÊäÈëµçÑ¹ vbus_v ´ïµ½Ä¿±êÖµ£¨ PFC_VBUS_READY_V £©£¬²¢±£³ÖÒ»¶ÎÊ±¼ä£¨ PFC_READY_DELAY_MS £©½øÈëready×´Ì¬
+			//è¾“å…¥ç”µå‹ vbus_v è¾¾åˆ°ç›®æ ‡å€¼ï¼ˆ PFC_VBUS_READY_V ï¼‰ï¼Œå¹¶ä¿æŒä¸€æ®µæ—¶é—´ï¼ˆ PFC_READY_DELAY_MS ï¼‰è¿›å…¥readyçŠ¶æ€
 			if(vbus_v>=PFC_VBUS_READY_V)
 			{
 				if(s_pfc_app.vbus_ok_since_ms == 0U)
@@ -717,7 +717,7 @@ void pfc_app_tick_1khz(float vbus_v)
 			}
 			else
 			{
-				s_pfc_app.vbus_ok_since_ms = 0; // ÖØĞÂ¼ÆÊ±
+				s_pfc_app.vbus_ok_since_ms = 0; // é‡æ–°è®¡æ—¶
 			}
 			break;
 		case PFC_ST_READY:
@@ -726,7 +726,7 @@ void pfc_app_tick_1khz(float vbus_v)
 				pfc_state_enter(PFC_ST_IDLE);
 				break;
 			}
-	//ÊäÈëµçÑ¹µÍÓÚãĞÖµ£¨ PFC_VBUS_READY_V - PFC_VBUS_READY_HYST_V £©£¬²¢³ÖĞøÒ»¶¨Ê±¼ä£¨ PFC_VBUS_DROPOUT_MS £©¡£
+	//è¾“å…¥ç”µå‹ä½äºé˜ˆå€¼ï¼ˆ PFC_VBUS_READY_V - PFC_VBUS_READY_HYST_V ï¼‰ï¼Œå¹¶æŒç»­ä¸€å®šæ—¶é—´ï¼ˆ PFC_VBUS_DROPOUT_MS ï¼‰ã€‚
 			if(vbus_v >= (PFC_VBUS_READY_V - PFC_VBUS_READY_HYST_V))
 			{
 				s_pfc_app.dropout_since_ms = 0U;
@@ -780,41 +780,41 @@ float pfc_bus_voltage(void)
 }
 
 void llc_step(llc_t* l){
-	/* 1) Îó²î£ºÄ¿±êµçÑ¹ - Êµ²âµçÑ¹£¨µ¥Î»V£© */
+	/* 1) è¯¯å·®ï¼šç›®æ ‡ç”µå‹ - å®æµ‹ç”µå‹ï¼ˆå•ä½Vï¼‰ */
     float e = l->vref - l->vmeas;
-	/* 2) »ı·ÖÀÛ¼Ó£ºÃ¿¸ö¿ØÖÆÖÜÆÚÔö¼Ó ki*e£¨²»¿¼ÂÇ±¥ºÍ£© */
+	/* 2) ç§¯åˆ†ç´¯åŠ ï¼šæ¯ä¸ªæ§åˆ¶å‘¨æœŸå¢åŠ  ki*eï¼ˆä¸è€ƒè™‘é¥±å’Œï¼‰ */
     l->integ += l->ki * e;
-	/* 3) PIÊä³öÓ³Éäµ½ÆµÂÊÇëÇó£ºkp*e + I£¬ÔÙ¼Ó»ùÏß f_min£¨µ¥Î»Hz£© */
+	/* 3) PIè¾“å‡ºæ˜ å°„åˆ°é¢‘ç‡è¯·æ±‚ï¼škp*e + Iï¼Œå†åŠ åŸºçº¿ f_minï¼ˆå•ä½Hzï¼‰ */
     float f_req = l->kp * e + l->integ + l->f_min;
-	/* 4) ÏŞ·ù */
-    if(f_req < l->f_min)   // ÆµÂÊÏÂÏŞÇ¯Î»£º²»¿ÉµÍÓÚ f_min
+	/* 4) é™å¹… */
+    if(f_req < l->f_min)   // é¢‘ç‡ä¸‹é™é’³ä½ï¼šä¸å¯ä½äº f_min
 			f_req = l->f_min;
-    if(f_req > l->f_max)   // ÆµÂÊÉÏÏŞÇ¯Î»£º²»¿É¸ßÓÚ f_max
+    if(f_req > l->f_max)   // é¢‘ç‡ä¸Šé™é’³ä½ï¼šä¸å¯é«˜äº f_max
 			f_req = l->f_max;
 		
-    float df = f_req - l->f_cmd;  // ÆÚÍûÆµÂÊÓëµ±Ç°ÏÂ·¢ÆµÂÊµÄ²îÖµ ¦¤f
+    float df = f_req - l->f_cmd;  // æœŸæœ›é¢‘ç‡ä¸å½“å‰ä¸‹å‘é¢‘ç‡çš„å·®å€¼ Î”f
 		
-    if(f_absf(df) > l->f_slew)   // Ğ±ÂÊÏŞ·ù£ºÈô |¦¤f| ´óÓÚÃ¿ÖÜÆÚ×î´ó²½³¤ f_slew
-			l->f_cmd += (df>0?l->f_slew:-l->f_slew); //¾Í°´Õı/¸º·½ÏòÖ»ÒÆ¶¯ f_slew£¨ÏŞËÙ±äÆµ£©
+    if(f_absf(df) > l->f_slew)   // æ–œç‡é™å¹…ï¼šè‹¥ |Î”f| å¤§äºæ¯å‘¨æœŸæœ€å¤§æ­¥é•¿ f_slew
+			l->f_cmd += (df>0?l->f_slew:-l->f_slew); //å°±æŒ‰æ­£/è´Ÿæ–¹å‘åªç§»åŠ¨ f_slewï¼ˆé™é€Ÿå˜é¢‘ï¼‰
     else 
-			l->f_cmd = f_req; // ·ñÔòÒ»²½µ½Î»£ºÖ±½Ó°ÑÏÂ·¢ÆµÂÊÉèÎªÄ¿±ê
+			l->f_cmd = f_req; // å¦åˆ™ä¸€æ­¥åˆ°ä½ï¼šç›´æ¥æŠŠä¸‹å‘é¢‘ç‡è®¾ä¸ºç›®æ ‡
 }
 
 /*********************************************************************************************************
-* º¯ÊıÃû³Æ£ºllc_state_enter
-* º¯Êı¹¦ÄÜ£º×´Ì¬»úÇĞ»»º¯Êı£¬ÓÃÓÚ¿ØÖÆ LLC£¨Ğ³Õñ±ä»»Æ÷£©µÄ²»Í¬¹¤×÷×´Ì¬
-* ÊäÈë²ÎÊı£ºnext
-* Êä³ö²ÎÊı£ºvoid
-* ·µ »Ø Öµ£ºvoid
-* ´´½¨ÈÕÆÚ£º202Äê10ÔÂ09ÈÕ
-* ×¢    Òâ£ºµ± LLC ĞèÒª´ÓÒ»¸ö×´Ì¬ÇĞ»»µ½ÁíÒ»¸ö×´Ì¬Ê±£¬´Ëº¯Êı»á±»µ÷ÓÃ£¬Ö´ĞĞÏàÓ¦µÄ³õÊ¼»¯»òÇåÀí²Ù×÷¡£
+* å‡½æ•°åç§°ï¼šllc_state_enter
+* å‡½æ•°åŠŸèƒ½ï¼šçŠ¶æ€æœºåˆ‡æ¢å‡½æ•°ï¼Œç”¨äºæ§åˆ¶ LLCï¼ˆè°æŒ¯å˜æ¢å™¨ï¼‰çš„ä¸åŒå·¥ä½œçŠ¶æ€
+* è¾“å…¥å‚æ•°ï¼šnext
+* è¾“å‡ºå‚æ•°ï¼švoid
+* è¿” å› å€¼ï¼švoid
+* åˆ›å»ºæ—¥æœŸï¼š202å¹´10æœˆ09æ—¥
+* æ³¨    æ„ï¼šå½“ LLC éœ€è¦ä»ä¸€ä¸ªçŠ¶æ€åˆ‡æ¢åˆ°å¦ä¸€ä¸ªçŠ¶æ€æ—¶ï¼Œæ­¤å‡½æ•°ä¼šè¢«è°ƒç”¨ï¼Œæ‰§è¡Œç›¸åº”çš„åˆå§‹åŒ–æˆ–æ¸…ç†æ“ä½œã€‚
 *********************************************************************************************************/
 static void llc_state_enter(llc_state_t next)
 {
 	s_llc_app.state = next;
 	s_llc_app.entry_ms = g_ms;
 	#if Bus_Adj
-	bus_vol_adj_reset();   //ÖØÖÃ×ÜÏßµçÑ¹µ÷ÕûÂß¼­ °Ù·ÖÖ®ÎåÊ®µÄÕ¼¿Õ±È
+	bus_vol_adj_reset();   //é‡ç½®æ€»çº¿ç”µå‹è°ƒæ•´é€»è¾‘ ç™¾åˆ†ä¹‹äº”åçš„å ç©ºæ¯”
 	#endif
 	switch(next)
 	{
@@ -834,7 +834,7 @@ static void llc_state_enter(llc_state_t next)
 			llc_open_loop_stop(&s_llc_open_loop);
 #endif
 			llc_softstart_reset();
-			pfc_app_request_start(); //¼ÇÂ¼ÇëÇóµÄÆğÊ¼Ê±¼ä
+			pfc_app_request_start(); //è®°å½•è¯·æ±‚çš„èµ·å§‹æ—¶é—´
 			llc_pwm_outputs_enable(0);
 			s_llc.integ = 0.0f;
 			s_llc.f_cmd = s_llc.f_min;
@@ -874,13 +874,13 @@ void llc_app_init()
 	llc_state_enter(ST_WAIT_VBUS);
 }
 /*********************************************************************************************************
-* º¯ÊıÃû³Æ£ºllc_state_enter
-* º¯Êı¹¦ÄÜ£º×´Ì¬»úÇĞ»»º¯Êı£¬ÓÃÓÚ¿ØÖÆ LLC£¨Ğ³Õñ±ä»»Æ÷£©µÄ²»Í¬¹¤×÷×´Ì¬
-* ÊäÈë²ÎÊı£ºnext
-* Êä³ö²ÎÊı£ºvoid
-* ·µ »Ø Öµ£ºvoid
-* ´´½¨ÈÕÆÚ£º2025Äê10ÔÂ09ÈÕ
-* ×¢    Òâ£ºµ± LLC ĞèÒª´ÓÒ»¸ö×´Ì¬ÇĞ»»µ½ÁíÒ»¸ö×´Ì¬Ê±£¬´Ëº¯Êı»á±»µ÷ÓÃ£¬Ö´ĞĞÏàÓ¦µÄ³õÊ¼»¯»òÇåÀí²Ù×÷¡£
+* å‡½æ•°åç§°ï¼šllc_state_enter
+* å‡½æ•°åŠŸèƒ½ï¼šçŠ¶æ€æœºåˆ‡æ¢å‡½æ•°ï¼Œç”¨äºæ§åˆ¶ LLCï¼ˆè°æŒ¯å˜æ¢å™¨ï¼‰çš„ä¸åŒå·¥ä½œçŠ¶æ€
+* è¾“å…¥å‚æ•°ï¼šnext
+* è¾“å‡ºå‚æ•°ï¼švoid
+* è¿” å› å€¼ï¼švoid
+* åˆ›å»ºæ—¥æœŸï¼š2025å¹´10æœˆ09æ—¥
+* æ³¨    æ„ï¼šå½“ LLC éœ€è¦ä»ä¸€ä¸ªçŠ¶æ€åˆ‡æ¢åˆ°å¦ä¸€ä¸ªçŠ¶æ€æ—¶ï¼Œæ­¤å‡½æ•°ä¼šè¢«è°ƒç”¨ï¼Œæ‰§è¡Œç›¸åº”çš„åˆå§‹åŒ–æˆ–æ¸…ç†æ“ä½œã€‚
 *********************************************************************************************************/
 void llc_app_tick_1khz(void)
 {
@@ -895,28 +895,28 @@ void llc_app_tick_1khz(void)
 			llc_state_enter(ST_WAIT_VBUS);
 			break;
 		case ST_WAIT_VBUS:
-			//ĞèÂú×ã PFC ×¼±¸¾ÍĞ÷ÇÒµçÑ¹´ïµ½ãĞÖµ
+			//éœ€æ»¡è¶³ PFC å‡†å¤‡å°±ç»ªä¸”ç”µå‹è¾¾åˆ°é˜ˆå€¼
 			if(!pfc_app_ready()||s_llc.vmeas < LLC_ENTRY_V)
 			{
 				if (s_llc_app.entry_ms == 0U)
 				{
 					s_llc_app.entry_ms = g_ms;
 				}					
-				//ÎüºÏÖ÷¼ÌµçÆ÷
+				//å¸åˆä¸»ç»§ç”µå™¨
 				pfc_hw_set_relay(1);
 				llc_state_enter(ST_LLC_RUN); 
 				break;
 			}
 			else
 			{
-				s_llc_app.entry_ms = 0U;          // Ìõ¼şÖĞ¶Ï£¬ÖØĞÂ¼ÆÊ±
-				pfc_hw_set_relay(0);              // »¹Î´Âú×ã£¬±£³Ö¶Ï¿ª¸ü°²È«
+				s_llc_app.entry_ms = 0U;          // æ¡ä»¶ä¸­æ–­ï¼Œé‡æ–°è®¡æ—¶
+				pfc_hw_set_relay(0);              // è¿˜æœªæ»¡è¶³ï¼Œä¿æŒæ–­å¼€æ›´å®‰å…¨
 			}
-			break;                                 // <<< ±ØĞëÓĞ
+			break;                                 // <<< å¿…é¡»æœ‰
 
 		case ST_LLC_RUN:
-			 // ÔËĞĞÖĞ£º²»¾ÍĞ÷»òµçÑ¹µøÆÆ¡°½øÈëãĞÖµ-³ÙÖÍ¡±¡ú ÍË»ØµÈ´ı
-			//Èç¹ûÈÎÒ»Ìõ¼ş³ÉÁ¢£¨PFCÎ´¾ÍĞ÷ »ò µçÑ¹¹ıµÍ£©£¬Ôòµ÷ÓÃ llc_state_enter(ST_WAIT_VBUS) £¬ÇĞ»»ÖÁµÈ´ıVBUS×´Ì¬¡£
+			 // è¿è¡Œä¸­ï¼šä¸å°±ç»ªæˆ–ç”µå‹è·Œç ´â€œè¿›å…¥é˜ˆå€¼-è¿Ÿæ»â€â†’ é€€å›ç­‰å¾…
+			//å¦‚æœä»»ä¸€æ¡ä»¶æˆç«‹ï¼ˆPFCæœªå°±ç»ª æˆ– ç”µå‹è¿‡ä½ï¼‰ï¼Œåˆ™è°ƒç”¨ llc_state_enter(ST_WAIT_VBUS) ï¼Œåˆ‡æ¢è‡³ç­‰å¾…VBUSçŠ¶æ€ã€‚
 			if(!pfc_app_ready()||s_llc.vmeas<(LLC_ENTRY_V-PFC_VBUS_READY_HYST_V))
 			{
 				pfc_hw_set_relay(0);
@@ -940,15 +940,15 @@ void SysTick_Handler(void){
 }
 
 /*********************************************************************************************************
-* º¯ÊıÃû³Æ£ºcontrol_loop_tick_1khz
-* º¯Êı¹¦ÄÜ£ºÖ÷ÒªÓÃÓÚÊµÊ±¿ØÖÆµçÁ¦µç×ÓÏµÍ³ÖĞµÄ¹¦ÂÊ×ª»»Ä£¿é
-* ÊäÈë²ÎÊı£ºnext
-* Êä³ö²ÎÊı£ºvoid
-* ·µ »Ø Öµ£ºvoid
-* ´´½¨ÈÕÆÚ£º2025Äê10ÔÂ09ÈÕ
-* ×¢    Òâ£ºÊı¾İ²É¼¯Óë×ª»»£ºÍ¨¹ıADC¶ÁÈ¡Êä³öµçÑ¹µÄÔ­Ê¼Êı¾İ£¬²¢½«Æä×ª»»ÎªÊµ¼ÊµÄµçÑ¹Öµ¡£
-						¸ù¾İÏµÍ³×´Ì¬£¨ÈçLLCÊÇ·ñÔËĞĞ£©Ö´ĞĞ²»Í¬µÄ¿ØÖÆÂß¼­
-						¶¯Ì¬µ÷ÕûLLCµÄ¹¤×÷ÆµÂÊ£¬È·±£ÏµÍ³ÎÈ¶¨ÔËĞĞ¡£
+* å‡½æ•°åç§°ï¼šcontrol_loop_tick_1khz
+* å‡½æ•°åŠŸèƒ½ï¼šä¸»è¦ç”¨äºå®æ—¶æ§åˆ¶ç”µåŠ›ç”µå­ç³»ç»Ÿä¸­çš„åŠŸç‡è½¬æ¢æ¨¡å—
+* è¾“å…¥å‚æ•°ï¼šnext
+* è¾“å‡ºå‚æ•°ï¼švoid
+* è¿” å› å€¼ï¼švoid
+* åˆ›å»ºæ—¥æœŸï¼š2025å¹´10æœˆ09æ—¥
+* æ³¨    æ„ï¼šæ•°æ®é‡‡é›†ä¸è½¬æ¢ï¼šé€šè¿‡ADCè¯»å–è¾“å‡ºç”µå‹çš„åŸå§‹æ•°æ®ï¼Œå¹¶å°†å…¶è½¬æ¢ä¸ºå®é™…çš„ç”µå‹å€¼ã€‚
+						æ ¹æ®ç³»ç»ŸçŠ¶æ€ï¼ˆå¦‚LLCæ˜¯å¦è¿è¡Œï¼‰æ‰§è¡Œä¸åŒçš„æ§åˆ¶é€»è¾‘
+						åŠ¨æ€è°ƒæ•´LLCçš„å·¥ä½œé¢‘ç‡ï¼Œç¡®ä¿ç³»ç»Ÿç¨³å®šè¿è¡Œã€‚
 *********************************************************************************************************/
 static void control_loop_tick_1khz(void){
     /* 1 kHz control */
@@ -991,8 +991,8 @@ int main(void){
 	  debug_printf_init(DEBUG_PRINTF_DEFAULT_BAUDRATE);
 	  debug_printf("Debug console initialized @%lu baud\n", (unsigned long)DEBUG_PRINTF_DEFAULT_BAUDRATE);
 
-    /* LLC complementary PWM ÅäÖÃLLCµÄPWMÆµÂÊ ¡¢ËÀÇøÊ±¼äºÍÕ¼¿Õ±È£¬²¢³õÊ¼»¯PWMÄ£¿é*/
-    llc_pwm_cfg_t lcfg = { .pwm_hz=LLC_PWM_BASE_HZ, .deadtime_ns=LLC_PWM_DEAD_NS, .duty=LLC_PWM_DUTY };
+    /* ADC multi (PA3/PA1 removed) triggered by TIMER0 CH2 at PWM midpoint for coherence */
+    adc_multi_init_dma(ADC0_1_EXTTRIG_REGULAR_T0_CH2); 
     llc_pwm_init(&lcfg);
 
     /* Aux PWM on PB0 */
@@ -1014,7 +1014,7 @@ int main(void){
     /* Protection EXTI PC11 */
     protect_exti_init();
 
-    /* LLC control default¡£³õÊ¼»¯LLCµÄ¿ØÖÆ²ÎÊı£¬°üÀ¨Ä¿±êµçÑ¹¡¢PID²ÎÊı¡¢ÆµÂÊ·¶Î§ºÍ³õÊ¼ÆµÂÊ¡£*/
+    /* LLC control defaultã€‚åˆå§‹åŒ–LLCçš„æ§åˆ¶å‚æ•°ï¼ŒåŒ…æ‹¬ç›®æ ‡ç”µå‹ã€PIDå‚æ•°ã€é¢‘ç‡èŒƒå›´å’Œåˆå§‹é¢‘ç‡ã€‚*/
     s_llc = (llc_t){ 
 			.vref=VBUS_TARGET_V, .vmeas=0.0f, .kp=0.01f, .ki=0.0005f,
       .f_min=LLC_F_MIN_HZ, .f_max=LLC_F_MAX_HZ, .f_cmd=LLC_F_INIT_HZ, .f_slew=LLC_F_SLEW_HZ 
@@ -1032,12 +1032,12 @@ int main(void){
 #endif
     while(1){
 			uint32_t pending_ticks = 0U;
-			float  duty0, duty1; //PA3 PA1²¶»ñµÄÖµ
+			float  duty0, duty1; //PA3 PA1æ•è·çš„å€¼
 			//__disable_irq();
 			if(s_control_tick_pending > 0U)
 			{
-					pending_ticks = s_control_tick_pending; //pending_ticks £ºÓÃÓÚÖğ¸ö´¦Àí´ıÖ´ĞĞµÄ¿ØÖÆÈÎÎñ¡£
-					s_control_tick_pending = 0U;  //¼ÇÂ¼´ı´¦ÀíµÄ¿ØÖÆÖÜÆÚÈÎÎñÊıÁ¿¡£
+					pending_ticks = s_control_tick_pending; //pending_ticks ï¼šç”¨äºé€ä¸ªå¤„ç†å¾…æ‰§è¡Œçš„æ§åˆ¶ä»»åŠ¡ã€‚
+					s_control_tick_pending = 0U;  //è®°å½•å¾…å¤„ç†çš„æ§åˆ¶å‘¨æœŸä»»åŠ¡æ•°é‡ã€‚
 			}
 			//__enable_irq();
 			while(pending_ticks-- > 0U)
@@ -1059,7 +1059,7 @@ int main(void){
 #endif
 			}
 			//if(protect_fault_latched()){
-				//¼ì²âµ½¹ÊÕÏ£¨Í¨¹ıPC11ÖĞ¶Ï£©£¬Ôò¹Ø±ÕLLCµÄPWMÊä³ö£¬²¢±ê¼ÇĞèÒª½øÒ»²½´¦Àí¹ÊÕÏ¡£
+				//æ£€æµ‹åˆ°æ•…éšœï¼ˆé€šè¿‡PC11ä¸­æ–­ï¼‰ï¼Œåˆ™å…³é—­LLCçš„PWMè¾“å‡ºï¼Œå¹¶æ ‡è®°éœ€è¦è¿›ä¸€æ­¥å¤„ç†æ•…éšœã€‚
 				//  llc_pwm_outputs_enable(0);
 					/* TODO: fault handling */
 			//}

--- a/0917/HW/include/add_dma.h
+++ b/0917/HW/include/add_dma.h
@@ -21,35 +21,35 @@ static volatile adc_multi_frame_t s_latched;
 
 extern volatile adc_multi_frame_t g_adc_multi;
 
-void adc_multi_init_dma(uint32_t trig_src /* e.g. ADC_EXTTRIG_REGULAR_T0_CH0 */);
+void adc_multi_init_dma(uint32_t trig_src /* e.g. ADC0_1_EXTTRIG_REGULAR_T0_CH2 */);
 void adc_multi_start(void);
 void adc_multi_copy(void);
 
 /*
-# ADC �ɼ���������
+- 鳤Ϊ 6ʱͳһΪ 55.5 ڣԼ 20sͨ `adc_external_trigger_source_config` Ϊ `TIMER0 CH2` 
+- `adc_multi_start` ͨ `LLC_PWM_TIMER` ¼`TIMER_EVENT_SRC_CH2G`״ת LLC PWM Ʊʱһ¡
+1. **ͬ**ADC ⲿԴ `trig_src` 룬÷ǰ̶Ϊ `ADC0_1_EXTTRIG_REGULAR_T0_CH2`ȷͶʱͬҪ֧ԴɿڽӿĵȷʱԼԼʱҪ
+- `adc_multi_init_dma` 在使能 DMA 之前调用 `analog_pins`，为 PA5/PA6/PA7、PB1、PC4/PC5 配置为模拟输入，覆盖 6 路采样点（Vout、电流、两路温度和两路电压检测）。
+- 采样通道次序固定，配合 `adc_multi_store_frame` 将 DMA 缓冲的每 6 个采样值按顺序锁存，确保上层读取时的语义一致。
 
-## Ӳ����Դ��ܽ�����
-- `adc_multi_init_dma` ��ʹ�� DMA ֮ǰ���� `analog_pins`��Ϊ PA5/PA6/PA7��PB1��PC4/PC5 ����Ϊģ�����룬���� 6 ·�����㣨Vout����������·�¶Ⱥ���·��ѹ��⣩��
-- ����ͨ������̶������ `adc_multi_store_frame` �� DMA �����ÿ 6 ������ֵ��˳�����棬ȷ���ϲ��ȡʱ������һ�¡�
+## 触发与速率控制
+- 常规组长度设置为 6，采样时间统一为 55.5 周期（约 20μs），并通过 `adc_external_trigger_source_config` 配置为 `TIMER0 CH0` 触发。
+- `adc_multi_start` 通过向 `LLC_PWM_TIMER` 触发软件事件（`TIMER_EVENT_SRC_CH0G`）启动首次转换，与 LLC PWM 控制保持时序一致。
 
-## ���������ʿ���
-- �����鳤������Ϊ 6������ʱ��ͳһΪ 55.5 ���ڣ�Լ 20��s������ͨ�� `adc_external_trigger_source_config` ����Ϊ `TIMER0 CH0` ������
-- `adc_multi_start` ͨ���� `LLC_PWM_TIMER` ���������¼���`TIMER_EVENT_SRC_CH0G`�������״�ת������ LLC PWM ���Ʊ���ʱ��һ�¡�
+## DMA 架构
+- DMA0 通道 0 工作在循环模式，目标为 `ADC_RDATA(ADC0)`，内存缓冲 `s_buf` 长度为 12（6 路 * 双缓冲），半传输/全传输中断分别写入缓存，形成“乒乓”行为。
+- 中断服务在清除标志后调用 `adc_multi_store_frame`，把有效半缓冲复制到 `s_latched`，随后 `adc_multi_copy` 在关中断的临界区内将其拷贝到全局 `g_adc_multi`，避免读写竞争。
 
-## DMA �ܹ�
-- DMA0 ͨ�� 0 ������ѭ��ģʽ��Ŀ��Ϊ `ADC_RDATA(ADC0)`���ڴ滺�� `s_buf` ����Ϊ 12��6 · * ˫���壩���봫��/ȫ�����жϷֱ�д�뻺�棬�γɡ�ƹ�ҡ���Ϊ��
-- �жϷ����������־����� `adc_multi_store_frame`������Ч�뻺�帴�Ƶ� `s_latched`����� `adc_multi_copy` �ڹ��жϵ��ٽ����ڽ��俽����ȫ�� `g_adc_multi`�������д������
+## 数值转换与上层使用
+- 上层在 `main.c` 中通过 `g_adc_multi` 获取原始值，并借助电阻分压/采样函数完成电压、电流换算，在调试模式下可直接输出原始与换算结果。
 
-## ��ֵת�����ϲ�ʹ��
-- �ϲ��� `main.c` ��ͨ�� `g_adc_multi` ��ȡԭʼֵ�������������ѹ/����������ɵ�ѹ���������㣬�ڵ���ģʽ�¿�ֱ�����ԭʼ�뻻������
+## 发现的问题与改进建议
+1. **触发与同步**：ADC 外部触发源由 `trig_src` 参数传入，调用方当前固定为 `ADC0_1_EXTTRIG_REGULAR_T0_CH0`，确保和定时器同步。如果后续需要支持其它触发源，可考虑在接口文档中明确时钟约束以及定时器配置要求。
+2. **缓冲管理**：`s_buf` 和 `s_latched` 定义在头文件里（`static`），每个包含者都会生成独立副本。目前只有 `adc_dma.c` 使用，但为避免误用，建议迁移到实现文件或改为 `extern` 声明。
+3. **误差与校准**：流程在 `adc_enable` 后执行 `adc_calibration_enable` 完成一次性校准，缺乏对 Vref 波动或温度的动态补偿。若对测量精度有更高要求，可引入定期重新校准或内部温度/参考电压的检测。
+4. **上层数据完整性**：`adc_multi_copy` 在调用者的上下文中执行，不带返回值指示新数据是否可用。若需要区分新旧数据，可增加帧计数或时间戳，避免重复处理旧样本。
 
-## ���ֵ�������Ľ�����
-1. **������ͬ��**��ADC �ⲿ����Դ�� `trig_src` �������룬���÷���ǰ�̶�Ϊ `ADC0_1_EXTTRIG_REGULAR_T0_CH0`��ȷ���Ͷ�ʱ��ͬ�������������Ҫ֧����������Դ���ɿ����ڽӿ��ĵ�����ȷʱ��Լ���Լ���ʱ������Ҫ��
-2. **�������**��`s_buf` �� `s_latched` ������ͷ�ļ��`static`����ÿ�������߶������ɶ���������Ŀǰֻ�� `adc_dma.c` ʹ�ã���Ϊ�������ã�����Ǩ�Ƶ�ʵ���ļ����Ϊ `extern` ������
-3. **�����У׼**�������� `adc_enable` ��ִ�� `adc_calibration_enable` ���һ����У׼��ȱ���� Vref �������¶ȵĶ�̬���������Բ��������и���Ҫ�󣬿����붨������У׼���ڲ��¶�/�ο���ѹ�ļ�⡣
-4. **�ϲ�����������**��`adc_multi_copy` �ڵ����ߵ���������ִ�У���������ֵָʾ�������Ƿ���á�����Ҫ�����¾����ݣ�������֡������ʱ����������ظ�������������
-
-## �������
-ADC �ɼ���·�� DMA ˫������϶�ʱ������ʵ���� 6 ͨ��ͬ�����������ݰ��˺ͻ��������ƺ�������Ҫ��ע����ͷ�ļ��о�̬����Ŀɼ����Լ�δ�����Ⱥ�����״̬��������չ����
+## 总体结论
+ADC 采集链路以 DMA 双缓冲配合定时器触发实现了 6 通道同步采样，数据搬运和互斥机制设计合理。需要关注的是头文件中静态缓冲的可见性以及未来精度和数据状态管理的扩展需求。
 */
 #endif

--- a/0917/HW/src/adc_dma.c
+++ b/0917/HW/src/adc_dma.c
@@ -25,26 +25,26 @@ static inline void adc_multi_store_frame(const uint16_t *src){
 static void dma_cfg(void){
     rcu_periph_clock_enable(RCU_DMA0);
     dma_parameter_struct d = {0}; 
-		dma_deinit(DMA0, DMA_CH0);  // ¸´Î» DMA0 µÄÍ¨µÀ 0£¬½«Æä¼Ä´æÆ÷»Ö¸´µ½Ä¬ÈÏ×´Ì¬
-    d.periph_addr=(uint32_t)&ADC_RDATA(ADC0);   // ÉèÖÃÍâÉèµØÖ·£¬Ö¸Ïò ADC0 µÄ¹æÔòÊý¾Ý¼Ä´æÆ÷
-    d.periph_inc=DMA_PERIPH_INCREASE_DISABLE;  // ½ûÖ¹ÍâÉèµØÖ·×ÔÔö£¬Ã¿´Î¶¼´ÓÍ¬Ò»¸ö ADC Êý¾Ý¼Ä´æÆ÷¶ÁÈ¡
-    d.memory_addr=(uint32_t)s_buf;     // ÉèÖÃÄÚ´æµØÖ·£¬Ö¸ÏòÓÃÓÚ»º´æ×ª»»½á¹ûµÄÊý×é
-    d.memory_inc=DMA_MEMORY_INCREASE_ENABLE;  // ÔÊÐíÄÚ´æµØÖ·×ÔÔö£¬Á¬ÐøÐ´Èë»º³åÇøµÄÃ¿¸öÔªËØ
-    d.periph_width=DMA_PERIPHERAL_WIDTH_16BIT;  // Ö¸¶¨ÍâÉèÊý¾Ý¿í¶ÈÎª 16 Î»£¬¶ÔÓ¦ ADC Êä³ö¿í¶È
-    d.memory_width=DMA_MEMORY_WIDTH_16BIT;    // Ö¸¶¨ÄÚ´æ´æ´¢¿í¶ÈÎª 16 Î»£¬ÓëÍâÉè¿í¶È±£³ÖÒ»ÖÂ
+		dma_deinit(DMA0, DMA_CH0);  // å¤ä½ DMA0 çš„é€šé“ 0ï¼Œå°†å…¶å¯„å­˜å™¨æ¢å¤åˆ°é»˜è®¤çŠ¶æ€
+    d.periph_addr=(uint32_t)&ADC_RDATA(ADC0);   // è®¾ç½®å¤–è®¾åœ°å€ï¼ŒæŒ‡å‘ ADC0 çš„è§„åˆ™æ•°æ®å¯„å­˜å™¨
+    d.periph_inc=DMA_PERIPH_INCREASE_DISABLE;  // ç¦æ­¢å¤–è®¾åœ°å€è‡ªå¢žï¼Œæ¯æ¬¡éƒ½ä»ŽåŒä¸€ä¸ª ADC æ•°æ®å¯„å­˜å™¨è¯»å–
+    d.memory_addr=(uint32_t)s_buf;     // è®¾ç½®å†…å­˜åœ°å€ï¼ŒæŒ‡å‘ç”¨äºŽç¼“å­˜è½¬æ¢ç»“æžœçš„æ•°ç»„
+    d.memory_inc=DMA_MEMORY_INCREASE_ENABLE;  // å…è®¸å†…å­˜åœ°å€è‡ªå¢žï¼Œè¿žç»­å†™å…¥ç¼“å†²åŒºçš„æ¯ä¸ªå…ƒç´ 
+    d.periph_width=DMA_PERIPHERAL_WIDTH_16BIT;  // æŒ‡å®šå¤–è®¾æ•°æ®å®½åº¦ä¸º 16 ä½ï¼Œå¯¹åº” ADC è¾“å‡ºå®½åº¦
+    d.memory_width=DMA_MEMORY_WIDTH_16BIT;    // æŒ‡å®šå†…å­˜å­˜å‚¨å®½åº¦ä¸º 16 ä½ï¼Œä¸Žå¤–è®¾å®½åº¦ä¿æŒä¸€è‡´
     //d.number=6;
-		//d.number=ADC_MULTI_CHANNEL_COUNT * 2U;  // Ã¿´Î DMA Ñ­»·Òª´«Êä 6 ¸öÊý¾ÝÏî£¬¶ÔÓ¦ 6 ¸ö¹æÔòÍ¨µÀµÄ½á¹û,Õâ±ßÅäÖÃÁËË«»º³åÇø
-    d.number=ADC_TIM0_TRIGGERED_COUNT  * 2U;  // ÅäÖÃË«»º³åÇø£¬Ã¿´Î DMA Ñ­»·´«Êä 6*2=12 ¸öÊý¾ÝÏî£¬Ç° 6 ¸öÓÃÓÚ°ë´«Êä£¨HTF£©£¬ºó 6 ¸öÓÃÓÚÈ«´«Êä£¨FTF£©£¬±ãÓÚË«»º³å´¦Àí
-    d.priority=DMA_PRIORITY_HIGH;   // ½«¸ÃÍ¨µÀÓÅÏÈ¼¶ÉèÎª¸ß£¬¼õÉÙ±»ÆäËû DMA ÈÎÎñÇÀÕ¼µÄ¸ÅÂÊ
-		d.direction=DMA_PERIPHERAL_TO_MEMORY;  // ÉèÖÃ´«Êä·½Ïò£º´ÓÍâÉè¶ÁÊý¾ÝÐ´ÈëÄÚ´æ
-    dma_init(DMA0, DMA_CH0, d);   // ÒÀ¾ÝÒÔÉÏ²ÎÊý³õÊ¼»¯ DMA0 Í¨µÀ 0
-    dma_circulation_enable(DMA0, DMA_CH0);   // Ê¹ÄÜÑ­»·Ä£Ê½£¬DMA ÔÚÍê³ÉÒ»ÂÖ´«Êäºó×Ô¶¯ÖØÐÂ¿ªÊ¼
+		//d.number=ADC_MULTI_CHANNEL_COUNT * 2U;  // æ¯æ¬¡ DMA å¾ªçŽ¯è¦ä¼ è¾“ 6 ä¸ªæ•°æ®é¡¹ï¼Œå¯¹åº” 6 ä¸ªè§„åˆ™é€šé“çš„ç»“æžœ,è¿™è¾¹é…ç½®äº†åŒç¼“å†²åŒº
+    d.number=ADC_TIM0_TRIGGERED_COUNT  * 2U;  // é…ç½®åŒç¼“å†²åŒºï¼Œæ¯æ¬¡ DMA å¾ªçŽ¯ä¼ è¾“ 6*2=12 ä¸ªæ•°æ®é¡¹ï¼Œå‰ 6 ä¸ªç”¨äºŽåŠä¼ è¾“ï¼ˆHTFï¼‰ï¼ŒåŽ 6 ä¸ªç”¨äºŽå…¨ä¼ è¾“ï¼ˆFTFï¼‰ï¼Œä¾¿äºŽåŒç¼“å†²å¤„ç†
+    d.priority=DMA_PRIORITY_HIGH;   // å°†è¯¥é€šé“ä¼˜å…ˆçº§è®¾ä¸ºé«˜ï¼Œå‡å°‘è¢«å…¶ä»– DMA ä»»åŠ¡æŠ¢å çš„æ¦‚çŽ‡
+		d.direction=DMA_PERIPHERAL_TO_MEMORY;  // è®¾ç½®ä¼ è¾“æ–¹å‘ï¼šä»Žå¤–è®¾è¯»æ•°æ®å†™å…¥å†…å­˜
+    dma_init(DMA0, DMA_CH0, d);   // ä¾æ®ä»¥ä¸Šå‚æ•°åˆå§‹åŒ– DMA0 é€šé“ 0
+    dma_circulation_enable(DMA0, DMA_CH0);   // ä½¿èƒ½å¾ªçŽ¯æ¨¡å¼ï¼ŒDMA åœ¨å®Œæˆä¸€è½®ä¼ è¾“åŽè‡ªåŠ¨é‡æ–°å¼€å§‹
     //dma_channel_enable(DMA0, DMA_CH0);
 		
-    // ¿ªÆô DMA0 Í¨µÀ0 µÄ¡°È«´«ÊäÍê³É¡±ÖÐ¶Ï£¨FTF£©£¬ÓÃÓÚÔÚËùÓÐÅäÖÃµÄÑù±¾´«ÊäÍê³Éºó´¥·¢»Øµ÷£¬ÊÊºÏÒ»´ÎÐÔ´¦ÀíÍêÕûÊý¾Ý¡£
+    // å¼€å¯ DMA0 é€šé“0 çš„â€œå…¨ä¼ è¾“å®Œæˆâ€ä¸­æ–­ï¼ˆFTFï¼‰ï¼Œç”¨äºŽåœ¨æ‰€æœ‰é…ç½®çš„æ ·æœ¬ä¼ è¾“å®ŒæˆåŽè§¦å‘å›žè°ƒï¼Œé€‚åˆä¸€æ¬¡æ€§å¤„ç†å®Œæ•´æ•°æ®ã€‚
     dma_interrupt_enable(DMA0, DMA_CH0, DMA_INT_FTF); 
 
-    // ¿ªÆô DMA0 Í¨µÀ0 µÄ¡°°ë´«ÊäÍê³É¡±ÖÐ¶Ï£¨HTF£©£¬ÓÃÓÚÔÚ°ë»º³åÇøÐ´ÂúÊ±ÌáÇ°ÏìÓ¦£¬ÊÊºÏË«»º³å»òÁ÷Ë®Ïß´¦Àí³¡¾°£¬Ìá¸ßÊý¾Ý´¦ÀíÊµÊ±ÐÔ¡£
+    // å¼€å¯ DMA0 é€šé“0 çš„â€œåŠä¼ è¾“å®Œæˆâ€ä¸­æ–­ï¼ˆHTFï¼‰ï¼Œç”¨äºŽåœ¨åŠç¼“å†²åŒºå†™æ»¡æ—¶æå‰å“åº”ï¼Œé€‚åˆåŒç¼“å†²æˆ–æµæ°´çº¿å¤„ç†åœºæ™¯ï¼Œæé«˜æ•°æ®å¤„ç†å®žæ—¶æ€§ã€‚
     dma_interrupt_enable(DMA0, DMA_CH0, DMA_INT_HTF);  
 
     dma_interrupt_flag_clear(DMA0, DMA_CH0, DMA_INT_FLAG_G);
@@ -53,17 +53,17 @@ static void dma_cfg(void){
 void adc_multi_init_dma(uint32_t trig_src){
     analog_pins(); 
     dma_cfg();
-    // ÉèÖÃ DMA0 Í¨µÀ0ÖÐ¶ÏÓÅÏÈ¼¶Îª 1£¨´Î¸ß£©£¬ÇÀÕ¼ÓÅÏÈ¼¶Îª 1£¬ÏìÓ¦ÓÅÏÈ¼¶Îª 0£¬È·±£ ADC ²É¼¯Êý¾Ý¼°Ê±´¦Àí£¬±ÜÃâÊý¾Ý¶ªÊ§
+    // è®¾ç½® DMA0 é€šé“0ä¸­æ–­ä¼˜å…ˆçº§ä¸º 1ï¼ˆæ¬¡é«˜ï¼‰ï¼ŒæŠ¢å ä¼˜å…ˆçº§ä¸º 1ï¼Œå“åº”ä¼˜å…ˆçº§ä¸º 0ï¼Œç¡®ä¿ ADC é‡‡é›†æ•°æ®åŠæ—¶å¤„ç†ï¼Œé¿å…æ•°æ®ä¸¢å¤±
     nvic_irq_enable(DMA0_Channel0_IRQn, 1U, 0U); 
     rcu_periph_clock_enable(RCU_ADC0);
     rcu_adc_clock_config(RCU_CKADC_CKAPB2_DIV6);
     adc_deinit(ADC0);
-    adc_mode_config(ADC_MODE_FREE); //ÉèÖÃ ADC Îª×ÔÓÉÔËÐÐÄ£Ê½£¨¶ÀÁ¢¹¤×÷£©¡£
-    adc_special_function_config(ADC0, ADC_SCAN_MODE, ENABLE); //ÆôÓÃÉ¨ÃèÄ£Ê½£¬Ö§³Ö¶àÍ¨µÀ²É¼¯¡£
-    adc_special_function_config(ADC0, ADC_CONTINUOUS_MODE, DISABLE); // ½ûÓÃÁ¬ÐøÄ£Ê½
-    adc_data_alignment_config(ADC0, ADC_DATAALIGN_RIGHT);//ÉèÖÃÊý¾Ý¶ÔÆë·½Ê½ÎªÓÒ¶ÔÆë¡£
+    adc_mode_config(ADC_MODE_FREE); //è®¾ç½® ADC ä¸ºè‡ªç”±è¿è¡Œæ¨¡å¼ï¼ˆç‹¬ç«‹å·¥ä½œï¼‰ã€‚
+    adc_special_function_config(ADC0, ADC_SCAN_MODE, ENABLE); //å¯ç”¨æ‰«ææ¨¡å¼ï¼Œæ”¯æŒå¤šé€šé“é‡‡é›†ã€‚
+	timer_event_software_generate(LLC_PWM_TIMER, TIMER_EVENT_SRC_CH2G); //Ê±Â¼É¿Í¬ ADC È·Ê±Ò»Ô¡
+    adc_data_alignment_config(ADC0, ADC_DATAALIGN_RIGHT);//è®¾ç½®æ•°æ®å¯¹é½æ–¹å¼ä¸ºå³å¯¹é½ã€‚
 
-    adc_channel_length_config(ADC0, ADC_REGULAR_CHANNEL, ADC_TIM0_TRIGGERED_COUNT);  // ÅäÖÃ ADC µÄ³£¹æÍ¨µÀÊýÁ¿¡£
+    adc_channel_length_config(ADC0, ADC_REGULAR_CHANNEL, ADC_TIM0_TRIGGERED_COUNT);  // é…ç½® ADC çš„å¸¸è§„é€šé“æ•°é‡ã€‚
     adc_regular_channel_config(ADC0, 0, VOUT_SENSE_CH,     ADC_SAMPLETIME_41POINT5); 
     adc_regular_channel_config(ADC0, 1, ADC_ISENSE_CH,     ADC_SAMPLETIME_7POINT5); 
     //adc_regular_channel_config(ADC0, 2, ADC_TSENSE_CH,     ADC_SAMPLETIME_55POINT5);
@@ -72,8 +72,8 @@ void adc_multi_init_dma(uint32_t trig_src){
     //adc_regular_channel_config(ADC0, 5, T_SENSE_LLCMOS_CH, ADC_SAMPLETIME_55POINT5);
 
     adc_external_trigger_source_config(ADC0, ADC_REGULAR_CHANNEL, trig_src);
-		//adc_external_trigger_edge_config(ADC0, ADC_REGULAR_CHANNEL, ADC_EXTTRIG_EDGE_RISING); // ÉÏÉýÑØ´¥·¢
-		ADC_CTL1(ADC0) |= (0x01 << 10); // EXTEN=01£¨ÉÏÉýÑØ´¥·¢£©
+		//adc_external_trigger_edge_config(ADC0, ADC_REGULAR_CHANNEL, ADC_EXTTRIG_EDGE_RISING); // ä¸Šå‡æ²¿è§¦å‘
+		ADC_CTL1(ADC0) |= (0x01 << 10); // EXTEN=01ï¼ˆä¸Šå‡æ²¿è§¦å‘ï¼‰
     adc_external_trigger_config(ADC0, ADC_REGULAR_CHANNEL, ENABLE);
 
     adc_enable(ADC0); 
@@ -84,8 +84,8 @@ void adc_multi_init_dma(uint32_t trig_src){
 
 void adc_multi_start(void)
 { 
-	//adc_software_trigger_enable(ADC0, ADC_REGULAR_CHANNEL); ÆôÓÃ ADC0 µÄÈí¼þ´¥·¢¹¦ÄÜ£¬Æô¶¯³£¹æÍ¨µÀµÄ²ÉÑù¡£
-	timer_event_software_generate(LLC_PWM_TIMER, TIMER_EVENT_SRC_CH0G); //¶¨Ê±Æ÷ÊÂ¼þµÄÉú³É¿ÉÒÔÓÃÓÚÍ¬²½ ADC ²ÉÑù»òÆäËûÍâÉè²Ù×÷£¬È·±£Ê±ÐòÒ»ÖÂÐÔ¡£
+	//adc_software_trigger_enable(ADC0, ADC_REGULAR_CHANNEL); å¯ç”¨ ADC0 çš„è½¯ä»¶è§¦å‘åŠŸèƒ½ï¼Œå¯åŠ¨å¸¸è§„é€šé“çš„é‡‡æ ·ã€‚
+	timer_event_software_generate(LLC_PWM_TIMER, TIMER_EVENT_SRC_CH0G); //å®šæ—¶å™¨äº‹ä»¶çš„ç”Ÿæˆå¯ä»¥ç”¨äºŽåŒæ­¥ ADC é‡‡æ ·æˆ–å…¶ä»–å¤–è®¾æ“ä½œï¼Œç¡®ä¿æ—¶åºä¸€è‡´æ€§ã€‚
 }
 void adc_multi_copy(void){
     adc_multi_frame_t frame;

--- a/0917/HW/src/pwm_llc.c
+++ b/0917/HW/src/pwm_llc.c
@@ -2,14 +2,26 @@
 #include "pwm_llc.h"
 #include "main.h"
 
-//GPIO£º¸ß±Û¡¢µÍ±Û¡¢N Êä³ö¶¼ÓÃ AF_PP£»BKIN=PB12 ÓÃ ÉÏÀ­ÊäÈë¡£
-//ËÀÇø£ºÈ·ÈÏ bdtr_deadtime_code_ns(350ns, 108MHz) µÃµ½Ô¼ 0x26£¨¡Ö352ns£©¡£
-//BKIN£º¶Ì½Ó PB12¡úGND£¬Ó¦µ±Ë²Ê±¹Ø¶Ï£¨MOE Çå£©£»ËÉ¿ªÔÚÒ»¸ö¸üĞÂÖÜÆÚºó×Ô¶¯»Ö¸´£¨Òò outputautostate=ENABLE£©¡£
-//±äÆµ£ºµ÷ÓÃ llc_pwm_set_freq() ºó£¬Ê¾²¨Æ÷¿´µ½Õ¼¿Õ²»Æ¯£»Èô¹Ì¶¨ 50%£¬°Ñ llc_pwm_set_freq() ÀïÖ±½ÓÉè CCR = ARR/2¡£
+
+static void update_adc_trigger_from_pwm(uint16_t pwm_ccr)
+{
+    uint16_t midpoint = pwm_ccr / 2U;
+
+    if ((midpoint == 0U) && (pwm_ccr > 0U))
+    {
+        midpoint = 1U;
+    }
+
+    timer_channel_output_pulse_value_config(TIMER0, TIMER_CH_2, midpoint);
+}
+//GPIOï¼šé«˜è‡‚ã€ä½è‡‚ã€N è¾“å‡ºéƒ½ç”¨ AF_PPï¼›BKIN=PB12 ç”¨ ä¸Šæ‹‰è¾“å…¥ã€‚
+//æ­»åŒºï¼šç¡®è®¤ bdtr_deadtime_code_ns(350ns, 108MHz) å¾—åˆ°çº¦ 0x26ï¼ˆâ‰ˆ352nsï¼‰ã€‚
+//BKINï¼šçŸ­æ¥ PB12â†’GNDï¼Œåº”å½“ç¬æ—¶å…³æ–­ï¼ˆMOE æ¸…ï¼‰ï¼›æ¾å¼€åœ¨ä¸€ä¸ªæ›´æ–°å‘¨æœŸåè‡ªåŠ¨æ¢å¤ï¼ˆå›  outputautostate=ENABLEï¼‰ã€‚
+//å˜é¢‘ï¼šè°ƒç”¨ llc_pwm_set_freq() åï¼Œç¤ºæ³¢å™¨çœ‹åˆ°å ç©ºä¸æ¼‚ï¼›è‹¥å›ºå®š 50%ï¼ŒæŠŠ llc_pwm_set_freq() é‡Œç›´æ¥è®¾ CCR = ARR/2ã€‚
 //#include "gd32f30x_timer.h"
 static llc_pwm_cfg_t s_cfg; 
 static uint32_t s_period=0; 
-//ÆäÄ¿µÄÊÇ½«Ò»¸ö¸¡µãÊıÏŞÖÆÔÚÖ¸¶¨µÄ·¶Î§ÄÚ
+//å…¶ç›®çš„æ˜¯å°†ä¸€ä¸ªæµ®ç‚¹æ•°é™åˆ¶åœ¨æŒ‡å®šçš„èŒƒå›´å†…
 static inline float clampf(float x,float a,float b)
 { 
 	return x<a?a:(x>b?b:x); 
@@ -20,15 +32,15 @@ static inline float clampf(float x,float a,float b)
 	//return (t>255)?255:(uint8_t)t;
 //}
 /*********************************************************************************************************
-* º¯ÊıÃû³Æ£ºbdtr_deadtime_code_ns
-* º¯Êı¹¦ÄÜ£ºÓÃÓÚÅäÖÃÓ²¼şÖĞµÄËÀÇøÊ±¼ä¼Ä´æÆ÷£¨BDTR£©
-* ÊäÈë²ÎÊı£ºdead_ns:ËÀÇøÊ±¼ä£¬µ¥Î»ÎªÄÉÃë
-						clk: Ê±ÖÓÆµÂÊ£¬µ¥Î»ÎªºÕ×È
-* Êä³ö²ÎÊı£º
-* ·µ »Ø Öµ£º ·µ»ØÒ»¸ö 8 Î»µÄÎŞ·ûºÅÕûÊı
-* ´´½¨ÈÕÆÚ£º2025Äê10ÔÂ08ÈÕ
-* ×¢    Òâ£º³¢ÊÔ²»Í¬µÄ·ÖÆµÒò×Ó£¨1x¡¢2x¡¢8x¡¢16x£©£¬ÕÒµ½ºÏÊÊµÄ¼ÆÊıÖµ·¶Î§¡£
-¸ù¾İ²»Í¬µÄ·ÖÆµÒò×Ó£¬µ÷Õû¼ÆÊıÖµ²¢Ó³Éäµ½ÌØ¶¨µÄ¼Ä´æÆ÷±àÂë·¶Î§¡£
+* å‡½æ•°åç§°ï¼šbdtr_deadtime_code_ns
+* å‡½æ•°åŠŸèƒ½ï¼šç”¨äºé…ç½®ç¡¬ä»¶ä¸­çš„æ­»åŒºæ—¶é—´å¯„å­˜å™¨ï¼ˆBDTRï¼‰
+* è¾“å…¥å‚æ•°ï¼šdead_ns:æ­»åŒºæ—¶é—´ï¼Œå•ä½ä¸ºçº³ç§’
+						clk: æ—¶é’Ÿé¢‘ç‡ï¼Œå•ä½ä¸ºèµ«å…¹
+* è¾“å‡ºå‚æ•°ï¼š
+* è¿” å› å€¼ï¼š è¿”å›ä¸€ä¸ª 8 ä½çš„æ— ç¬¦å·æ•´æ•°
+* åˆ›å»ºæ—¥æœŸï¼š2025å¹´10æœˆ08æ—¥
+* æ³¨    æ„ï¼šå°è¯•ä¸åŒçš„åˆ†é¢‘å› å­ï¼ˆ1xã€2xã€8xã€16xï¼‰ï¼Œæ‰¾åˆ°åˆé€‚çš„è®¡æ•°å€¼èŒƒå›´ã€‚
+æ ¹æ®ä¸åŒçš„åˆ†é¢‘å› å­ï¼Œè°ƒæ•´è®¡æ•°å€¼å¹¶æ˜ å°„åˆ°ç‰¹å®šçš„å¯„å­˜å™¨ç¼–ç èŒƒå›´ã€‚
 *********************************************************************************************************/
 static uint8_t bdtr_deadtime_code_ns(uint32_t dead_ns, uint32_t clk) 
 {
@@ -71,94 +83,106 @@ static void pins_init(void){
 
 static uint32_t timer0_clk_hz(void){
     uint32_t apb2 = rcu_clock_freq_get(CK_APB2);
-    return (RCU_CFG0 & RCU_CFG0_APB2PSC) ? (apb2 * 2U) : apb2;  // APB2·ÖÆµ¡Ù1 Ê± TIMx=APB¡Á2
+    return (RCU_CFG0 & RCU_CFG0_APB2PSC) ? (apb2 * 2U) : apb2;  // APB2åˆ†é¢‘â‰ 1 æ—¶ TIMx=APBÃ—2
 }
 /*********************************************************************************************************
-* º¯ÊıÃû³Æ£ºllc_pwm_init
-* º¯Êı¹¦ÄÜ£º¸Ãº¯ÊıÓÃÓÚÅäÖÃºÍ³õÊ¼»¯LLC PWMÄ£¿é£¬°üÀ¨¶¨Ê±Æ÷¡¢Êä³ö±È½ÏÍ¨µÀ¡¢Break/Deadtime½á¹¹ÌåµÈ¡£
-Ä¿µÄÊÇ³õÊ¼»¯Ò»¸öÓÃÓÚ LLC Ğ³Õñ±ä»»Æ÷µÄ PWM£¨Âö¿íµ÷ÖÆ£©¿ØÖÆÆ÷¡£
-* ÊäÈë²ÎÊı£ºcfg
-* Êä³ö²ÎÊı£ºvoid
-* ·µ »Ø Öµ£ºvoid
-* ´´½¨ÈÕÆÚ£º2025/09/29
-* ×¢    Òâ£ºµ÷ÓÃ´Ëº¯ÊıÇ°£¬ĞèÈ·±£Ïà¹ØÍâÉèÊ±ÖÓÒÑÊ¹ÄÜ¡£ ³õÊ¼»¯Íê³Éºó£¬PWMÄ£¿é»á×Ô¶¯Æô¶¯¡£
+* å‡½æ•°åç§°ï¼šllc_pwm_init
+* å‡½æ•°åŠŸèƒ½ï¼šè¯¥å‡½æ•°ç”¨äºé…ç½®å’Œåˆå§‹åŒ–LLC PWMæ¨¡å—ï¼ŒåŒ…æ‹¬å®šæ—¶å™¨ã€è¾“å‡ºæ¯”è¾ƒé€šé“ã€Break/Deadtimeç»“æ„ä½“ç­‰ã€‚
+ç›®çš„æ˜¯åˆå§‹åŒ–ä¸€ä¸ªç”¨äº LLC è°æŒ¯å˜æ¢å™¨çš„ PWMï¼ˆè„‰å®½è°ƒåˆ¶ï¼‰æ§åˆ¶å™¨ã€‚
+* è¾“å…¥å‚æ•°ï¼šcfg
+* è¾“å‡ºå‚æ•°ï¼švoid
+* è¿” å› å€¼ï¼švoid
+* åˆ›å»ºæ—¥æœŸï¼š2025/09/29
+* æ³¨    æ„ï¼šè°ƒç”¨æ­¤å‡½æ•°å‰ï¼Œéœ€ç¡®ä¿ç›¸å…³å¤–è®¾æ—¶é’Ÿå·²ä½¿èƒ½ã€‚ åˆå§‹åŒ–å®Œæˆåï¼ŒPWMæ¨¡å—ä¼šè‡ªåŠ¨å¯åŠ¨ã€‚
 *********************************************************************************************************/
-//³õÊ¼»¯¶¨Ê±Æ÷»ù±¾²ÎÊı
+//åˆå§‹åŒ–å®šæ—¶å™¨åŸºæœ¬å‚æ•°
 void llc_pwm_init(const llc_pwm_cfg_t* cfg){
     s_cfg=*cfg;
     pins_init();
-	/* ÆôÓÃTIMER0µÄÊ±ÖÓ */
+	/* å¯ç”¨TIMER0çš„æ—¶é’Ÿ */
     rcu_periph_clock_enable(RCU_TIMER0);
-		/* ¶¨ÒåTIMER0µÄ³õÊ¼»¯²ÎÊı½á¹¹Ìå */
+		/* å®šä¹‰TIMER0çš„åˆå§‹åŒ–å‚æ•°ç»“æ„ä½“ */
     timer_parameter_struct t;
    // timer_struct_para_init(&t);
 	
-    uint32_t tclk = timer0_clk_hz();                // Èç¹ûÄã¿âÀïÃ»ÓĞ´Ëºê£¬¼ûÎÄÄ©±¸×¢
-    //s_period = (tclk/(2U*s_cfg.pwm_hz)) - 1U;      /* ÖĞĞÄ¶ÔÆëÆµÂÊ¹«Ê½ */ //s_period ´æ´¢¼ÆËã³öµÄ PWM ÖÜÆÚÖµ¡£
-		s_period = (tclk/(2U*s_cfg.pwm_hz)) - 1U;     //µ¥±ß£¨±ßÑØ¶ÔÆë£©¼ÆÊıÄ£Ê½
+    uint32_t tclk = timer0_clk_hz();                // å¦‚æœä½ åº“é‡Œæ²¡æœ‰æ­¤å®ï¼Œè§æ–‡æœ«å¤‡æ³¨
+    //s_period = (tclk/(2U*s_cfg.pwm_hz)) - 1U;      /* ä¸­å¿ƒå¯¹é½é¢‘ç‡å…¬å¼ */ //s_period å­˜å‚¨è®¡ç®—å‡ºçš„ PWM å‘¨æœŸå€¼ã€‚
+		s_period = (tclk/(2U*s_cfg.pwm_hz)) - 1U;     //å•è¾¹ï¼ˆè¾¹æ²¿å¯¹é½ï¼‰è®¡æ•°æ¨¡å¼
 /* TIMER0 configuration */
-    t.prescaler         = 0;  // Ô¤·ÖÆµÆ÷ÉèÖÃÎª0£¨Êµ¼Ê·ÖÆµÏµÊıÎª0+1=1£©
-    //t.alignedmode       = TIMER_COUNTER_CENTER_BOTH; //¾ÓÖĞ¶ÔÆëÇÒÏòÉÏ/ÏòÏÂ¼ÆÊıµÄ¶ÏÑÔÄ£Ê½
-		t.alignedmode       = TIMER_COUNTER_EDGE;   //±ßÔµ¶ÔÆëÄ£Ê½
-    t.counterdirection  = TIMER_COUNTER_UP; // ÏòÉÏ¼ÆÊı
-    t.period            = s_period;   // ×Ô¶¯ÖØÔØÖµ  1
-    t.clockdivision     = TIMER_CKDIV_DIV1; // Ê±ÖÓ·ÖÆµÒò×ÓÎª1
-    t.repetitioncounter = 0; // ÖØ¸´¼ÆÊıÆ÷ÖµÎª0
-    timer_init(TIMER0, &t);
+    t.prescaler         = 0;  // é¢„åˆ†é¢‘å™¨è®¾ç½®ä¸º0ï¼ˆå®é™…åˆ†é¢‘ç³»æ•°ä¸º0+1=1ï¼‰
+    //t.alignedmode       = TIMER_COUNTER_CENTER_BOTH; //å±…ä¸­å¯¹é½ä¸”å‘ä¸Š/å‘ä¸‹è®¡æ•°çš„æ–­è¨€æ¨¡å¼
+		t.alignedmode       = TIMER_COUNTER_EDGE;   //è¾¹ç¼˜å¯¹é½æ¨¡å¼
+    t.counterdirection  = TIMER_COUNTER_UP; // å‘ä¸Šè®¡æ•°
+    t.period            = s_period;   // è‡ªåŠ¨é‡è½½å€¼  1
+    t.clockdivision     = TIMER_CKDIV_DIV1; // æ—¶é’Ÿåˆ†é¢‘å› å­ä¸º1
+    timer_oc_parameter_struct oc_mid = oc;
+    oc_mid.outputstate  = TIMER_CCX_DISABLE;
+    oc_mid.outputnstate = TIMER_CCXN_DISABLE;
+    timer_channel_output_config(TIMER0, TIMER_CH_2, &oc_mid);
+    timer_channel_output_mode_config(TIMER0, TIMER_CH_2, TIMER_OC_MODE_PWM0);
+    timer_channel_output_pulse_value_config(TIMER0, TIMER_CH_2, 0);
+    timer_channel_output_shadow_config(TIMER0, TIMER_CH_2, TIMER_OC_SHADOW_ENABLE);
 
-    /* === ÊÖ¶¯³õÊ¼»¯ OC ½á¹¹Ìå£¨ÎŞ para_init °æ±¾£©  OC ÅäÖÃ£ºÒ»¸öÍ¨µÀ + »¥²¹£¨°ëÇÅ£©  === */
+		timer_master_output_trigger_source_select(TIMER0, TIMER_TRI_OUT_SRC_CC2); //Í¨ 2 Ğ·Ò»Î²È½Æ¥Â¼Îª TRGO 
+{
+	uint16_t pwm_ccr = duty_to_ccr(duty);
+	timer_channel_output_pulse_value_config(TIMER0, LLC_PWM_CH, pwm_ccr);
+	update_adc_trigger_from_pwm(pwm_ccr);
+	uint16_t pwm_ccr = duty_to_ccr(s_cfg.duty);
+	TIMER_CH0CV(TIMER0) = pwm_ccr;
+	update_adc_trigger_from_pwm(pwm_ccr);
     timer_oc_parameter_struct oc;
-    oc.outputstate   = TIMER_CCX_ENABLE;  // Ê¹ÄÜÖ÷Êä³öÍ¨µÀ
+    oc.outputstate   = TIMER_CCX_ENABLE;  // ä½¿èƒ½ä¸»è¾“å‡ºé€šé“
     oc.outputnstate  = TIMER_CCXN_ENABLE;
-    oc.ocpolarity    = TIMER_OC_POLARITY_HIGH; // Í¨µÀ0Êä³ö¼«ĞÔÎª¸ßµçÆ½
-    oc.ocnpolarity   = TIMER_OCN_POLARITY_HIGH;  // Í¨µÀ0NÊä³ö¼«ĞÔÎª¸ßµçÆ½
-    oc.ocidlestate   = TIMER_OC_IDLE_STATE_LOW;   //¿ÕÏĞ×´Ì¬ÏÂÖ÷Êä³öÎªµÍµçÆ½
+    oc.ocpolarity    = TIMER_OC_POLARITY_HIGH; // é€šé“0è¾“å‡ºææ€§ä¸ºé«˜ç”µå¹³
+    oc.ocnpolarity   = TIMER_OCN_POLARITY_HIGH;  // é€šé“0Nè¾“å‡ºææ€§ä¸ºé«˜ç”µå¹³
+    oc.ocidlestate   = TIMER_OC_IDLE_STATE_LOW;   //ç©ºé—²çŠ¶æ€ä¸‹ä¸»è¾“å‡ºä¸ºä½ç”µå¹³
     oc.ocnidlestate  = TIMER_OCN_IDLE_STATE_LOW;
 		//oc.ocnidlestate  = TIMER_OCN_IDLE_STATE_LOW;
-		// Ó¦ÓÃÅäÖÃµ½TIMER0µÄÍ¨µÀ0,ÅäÖÃ¶¨Ê±Æ÷Í¨µÀµÄÊä³ö²ÎÊı
+		// åº”ç”¨é…ç½®åˆ°TIMER0çš„é€šé“0,é…ç½®å®šæ—¶å™¨é€šé“çš„è¾“å‡ºå‚æ•°
     timer_channel_output_config(TIMER0, LLC_PWM_CH, &oc);
-		// ÉèÖÃTIMER0µÄLLC_PWM_CHÍ¨µÀµÄÊä³öÄ£Ê½Îª±ê×¼PWMÄ£Ê½£¨TIMER_OC_MODE_PWM0)
-    timer_channel_output_mode_config(TIMER0, LLC_PWM_CH, TIMER_OC_MODE_PWM0); /*TIMER_OC_MODE_PWM0 !< Í¨µÀ»¥²¹Êä³ö×´Ì¬ */
+		// è®¾ç½®TIMER0çš„LLC_PWM_CHé€šé“çš„è¾“å‡ºæ¨¡å¼ä¸ºæ ‡å‡†PWMæ¨¡å¼ï¼ˆTIMER_OC_MODE_PWM0)
+    timer_channel_output_mode_config(TIMER0, LLC_PWM_CH, TIMER_OC_MODE_PWM0); /*TIMER_OC_MODE_PWM0 !< é€šé“äº’è¡¥è¾“å‡ºçŠ¶æ€ */
 		
-		// ÅäÖÃTIMER0µÄLLC_PWM_CHÍ¨µÀµÄ³õÊ¼Âö³åÖµ£¨Õ¼¿Õ±È£©
-		// ²ÎÊı0±íÊ¾³õÊ¼Õ¼¿Õ±ÈÎª0%£¨Êä³öµÍµçÆ½£©£¬³£ÓÃÓÚÈíÆô¶¯»ò°²È«³õÊ¼»¯
+		// é…ç½®TIMER0çš„LLC_PWM_CHé€šé“çš„åˆå§‹è„‰å†²å€¼ï¼ˆå ç©ºæ¯”ï¼‰
+		// å‚æ•°0è¡¨ç¤ºåˆå§‹å ç©ºæ¯”ä¸º0%ï¼ˆè¾“å‡ºä½ç”µå¹³ï¼‰ï¼Œå¸¸ç”¨äºè½¯å¯åŠ¨æˆ–å®‰å…¨åˆå§‹åŒ–
     timer_channel_output_pulse_value_config(TIMER0, LLC_PWM_CH, 0);
-		// ÆôÓÃTIMER0µÄLLC_PWM_CHÍ¨µÀµÄÓ°×Ó¼Ä´æÆ÷£¨TIMER_OC_SHADOW_ENABLE£©
-		// ×÷ÓÃ£ºÈ·±£ÅäÖÃÔÚÏÂÒ»´Î¸üĞÂÊÂ¼şÊ±ÉúĞ§£¬±ÜÃâÔËĞĞÊ±ÅäÖÃ³åÍ»
-		// ¹Ø¼üµã£ºÓ°×Ó¼Ä´æÆ÷ÓÃÓÚ±£Ö¤ÅäÖÃµÄÔ­×ÓĞÔºÍÊµÊ±ĞÔ
+		// å¯ç”¨TIMER0çš„LLC_PWM_CHé€šé“çš„å½±å­å¯„å­˜å™¨ï¼ˆTIMER_OC_SHADOW_ENABLEï¼‰
+		// ä½œç”¨ï¼šç¡®ä¿é…ç½®åœ¨ä¸‹ä¸€æ¬¡æ›´æ–°äº‹ä»¶æ—¶ç”Ÿæ•ˆï¼Œé¿å…è¿è¡Œæ—¶é…ç½®å†²çª
+		// å…³é”®ç‚¹ï¼šå½±å­å¯„å­˜å™¨ç”¨äºä¿è¯é…ç½®çš„åŸå­æ€§å’Œå®æ—¶æ€§
     timer_channel_output_shadow_config(TIMER0, LLC_PWM_CH, TIMER_OC_SHADOW_ENABLE); 
 
-    /* === ÊÖ¶¯³õÊ¼»¯ Break/Deadtime ½á¹¹Ìå£¨ÎŞ para_init °æ±¾£© === */
-		//ËÀÇøÊ±¼äÓë±£»¤ÅäÖÃ
+    /* === æ‰‹åŠ¨åˆå§‹åŒ– Break/Deadtime ç»“æ„ä½“ï¼ˆæ—  para_init ç‰ˆæœ¬ï¼‰ === */
+		//æ­»åŒºæ—¶é—´ä¸ä¿æŠ¤é…ç½®
     timer_break_parameter_struct bk;
-    bk.runoffstate     = TIMER_ROS_STATE_DISABLE ; //ÉèÖÃ¶¨Ê±Æ÷ÔÚÔËĞĞ×´Ì¬ÏÂµÄ¶ÏÂ·ĞĞÎªÎª½ûÓÃ¡£ÕâÒâÎ¶×ÅÔÚÕı³£ÔËĞĞÆÚ¼ä£¬¶ÏÂ·¹¦ÄÜ²»»á´¥·¢¡£
-    bk.ideloffstate    = TIMER_IOS_STATE_DISABLE ; //ÉèÖÃ¶¨Ê±Æ÷ÔÚ¿ÕÏĞ×´Ì¬ÏÂµÄ¶ÏÂ·ĞĞÎªÎª½ûÓÃ¡£Óë runoffstate ÀàËÆ£¬µ«ÔÚ¿ÕÏĞ×´Ì¬ÏÂ²»ÆôÓÃ¶ÏÂ·¹¦ÄÜ¡£
-    bk.protectmode     = TIMER_CCHP_PROT_OFF; //ÉèÖÃ±£»¤Ä£Ê½Îª¹Ø±Õ¡£Õâ±íÊ¾¶¨Ê±Æ÷²»»áÆôÓÃ¶îÍâµÄ±£»¤»úÖÆ¡£
-		//¼ÆËã²¢ÉèÖÃËÀÇøÊ±¼ä£¨Dead Time£©¡£ËÀÇøÊ±¼äÊÇPWMĞÅºÅÖĞ¸ßµçÆ½ºÍµÍµçÆ½Ö®¼äµÄ¼ä¸ô£¬ÓÃÓÚ·ÀÖ¹ÉÏÏÂÇÅ±ÛÍ¬Ê±µ¼Í¨µ¼ÖÂµÄ¶ÌÂ·¡£
+    bk.runoffstate     = TIMER_ROS_STATE_DISABLE ; //è®¾ç½®å®šæ—¶å™¨åœ¨è¿è¡ŒçŠ¶æ€ä¸‹çš„æ–­è·¯è¡Œä¸ºä¸ºç¦ç”¨ã€‚è¿™æ„å‘³ç€åœ¨æ­£å¸¸è¿è¡ŒæœŸé—´ï¼Œæ–­è·¯åŠŸèƒ½ä¸ä¼šè§¦å‘ã€‚
+    bk.ideloffstate    = TIMER_IOS_STATE_DISABLE ; //è®¾ç½®å®šæ—¶å™¨åœ¨ç©ºé—²çŠ¶æ€ä¸‹çš„æ–­è·¯è¡Œä¸ºä¸ºç¦ç”¨ã€‚ä¸ runoffstate ç±»ä¼¼ï¼Œä½†åœ¨ç©ºé—²çŠ¶æ€ä¸‹ä¸å¯ç”¨æ–­è·¯åŠŸèƒ½ã€‚
+    bk.protectmode     = TIMER_CCHP_PROT_OFF; //è®¾ç½®ä¿æŠ¤æ¨¡å¼ä¸ºå…³é—­ã€‚è¿™è¡¨ç¤ºå®šæ—¶å™¨ä¸ä¼šå¯ç”¨é¢å¤–çš„ä¿æŠ¤æœºåˆ¶ã€‚
+		//è®¡ç®—å¹¶è®¾ç½®æ­»åŒºæ—¶é—´ï¼ˆDead Timeï¼‰ã€‚æ­»åŒºæ—¶é—´æ˜¯PWMä¿¡å·ä¸­é«˜ç”µå¹³å’Œä½ç”µå¹³ä¹‹é—´çš„é—´éš”ï¼Œç”¨äºé˜²æ­¢ä¸Šä¸‹æ¡¥è‡‚åŒæ—¶å¯¼é€šå¯¼è‡´çš„çŸ­è·¯ã€‚
     bk.deadtime        = bdtr_deadtime_code_ns(s_cfg.deadtime_ns, tclk);
-		//ÆôÓÃ¶ÏÂ·¹¦ÄÜ¡£µ±¼ì²âµ½Òì³£ĞÅºÅ£¨ÈçBKINÒı½ÅµÄµÍµçÆ½£©Ê±£¬¶¨Ê±Æ÷»á½øÈë¶ÏÂ·×´Ì¬¡£
+		//å¯ç”¨æ–­è·¯åŠŸèƒ½ã€‚å½“æ£€æµ‹åˆ°å¼‚å¸¸ä¿¡å·ï¼ˆå¦‚BKINå¼•è„šçš„ä½ç”µå¹³ï¼‰æ—¶ï¼Œå®šæ—¶å™¨ä¼šè¿›å…¥æ–­è·¯çŠ¶æ€ã€‚
     bk.breakstate      = TIMER_BREAK_ENABLE;
-		//ÉèÖÃ¶ÏÂ·ĞÅºÅµÄ¼«ĞÔÎªµÍµçÆ½ÓĞĞ§¡£ÕâÒâÎ¶×Åµ±BKINÒı½ÅÎªµÍµçÆ½Ê±£¬»á´¥·¢¶ÏÂ·¡£
-    bk.breakpolarity   = TIMER_BREAK_POLARITY_LOW;     // BKIN µÍÓĞĞ§
-		//ÆôÓÃÊä³ö×Ô¶¯×´Ì¬¡£ÔÚ¶ÏÂ·´¥·¢Ê±£¬¶¨Ê±Æ÷µÄÊä³ö»á×Ô¶¯ÇĞ»»µ½Ô¤¶¨ÒåµÄ°²È«×´Ì¬£¨Í¨³£ÊÇ¹Ø±ÕÊä³ö£©¡£
+		//è®¾ç½®æ–­è·¯ä¿¡å·çš„ææ€§ä¸ºä½ç”µå¹³æœ‰æ•ˆã€‚è¿™æ„å‘³ç€å½“BKINå¼•è„šä¸ºä½ç”µå¹³æ—¶ï¼Œä¼šè§¦å‘æ–­è·¯ã€‚
+    bk.breakpolarity   = TIMER_BREAK_POLARITY_LOW;     // BKIN ä½æœ‰æ•ˆ
+		//å¯ç”¨è¾“å‡ºè‡ªåŠ¨çŠ¶æ€ã€‚åœ¨æ–­è·¯è§¦å‘æ—¶ï¼Œå®šæ—¶å™¨çš„è¾“å‡ºä¼šè‡ªåŠ¨åˆ‡æ¢åˆ°é¢„å®šä¹‰çš„å®‰å…¨çŠ¶æ€ï¼ˆé€šå¸¸æ˜¯å…³é—­è¾“å‡ºï¼‰ã€‚
     bk.outputautostate = TIMER_OUTAUTO_ENABLE;				
 
     timer_break_config(TIMER0, &bk);
-		// ÅäÖÃÖ÷Êä³ö´¥·¢Ô´ÎªÍ¨µÀ0µÄ±È½ÏÊä³ö,Í¨¹ıÅäÖÃ´¥·¢Ô´£¬
-		//¶¨Ê±Æ÷¿ÉÒÔÔÚÌØ¶¨ÊÂ¼ş£¨Èç±È½ÏÆ¥Åä£©Ê±Éú³É´¥·¢ĞÅºÅ£¬ÓÃÓÚÍ¬²½ÆäËûÓ²¼şÄ£¿é£¨ÈçADC»òÆäËû¶¨Ê±Æ÷£©¡£
-		timer_master_output_trigger_source_select(TIMER0, TIMER_TRI_OUT_SRC_CC0); //ÔÚÍ¨µÀ 0 ÖĞ·¢ÉúÁËÒ»´Î²¶»ñ»ò±È½ÏÆ¥ÅäÊÂ¼ş£¬´¥·¢Êä³öÎª TRGO ¡£
-		//ÆôÓÃ¶¨Ê±Æ÷µÄ×Ô¶¯ÖØÔØÓ°×Ó¼Ä´æÆ÷¹¦ÄÜ¡£¶¨Ê±Æ÷µÄÖØÔØÖµ»áÔÚÏÂÒ»¸ö¸üĞÂÊÂ¼şÊ±ÉúĞ§£¬È·±£ÅäÖÃµÄÆ½»¬ÇĞ»»¡£
+		// é…ç½®ä¸»è¾“å‡ºè§¦å‘æºä¸ºé€šé“0çš„æ¯”è¾ƒè¾“å‡º,é€šè¿‡é…ç½®è§¦å‘æºï¼Œ
+		//å®šæ—¶å™¨å¯ä»¥åœ¨ç‰¹å®šäº‹ä»¶ï¼ˆå¦‚æ¯”è¾ƒåŒ¹é…ï¼‰æ—¶ç”Ÿæˆè§¦å‘ä¿¡å·ï¼Œç”¨äºåŒæ­¥å…¶ä»–ç¡¬ä»¶æ¨¡å—ï¼ˆå¦‚ADCæˆ–å…¶ä»–å®šæ—¶å™¨ï¼‰ã€‚
+		timer_master_output_trigger_source_select(TIMER0, TIMER_TRI_OUT_SRC_CC0); //åœ¨é€šé“ 0 ä¸­å‘ç”Ÿäº†ä¸€æ¬¡æ•è·æˆ–æ¯”è¾ƒåŒ¹é…äº‹ä»¶ï¼Œè§¦å‘è¾“å‡ºä¸º TRGO ã€‚
+		//å¯ç”¨å®šæ—¶å™¨çš„è‡ªåŠ¨é‡è½½å½±å­å¯„å­˜å™¨åŠŸèƒ½ã€‚å®šæ—¶å™¨çš„é‡è½½å€¼ä¼šåœ¨ä¸‹ä¸€ä¸ªæ›´æ–°äº‹ä»¶æ—¶ç”Ÿæ•ˆï¼Œç¡®ä¿é…ç½®çš„å¹³æ»‘åˆ‡æ¢ã€‚
     timer_auto_reload_shadow_enable(TIMER0);
-		//ÅäÖÃ¶¨Ê±Æ÷µÄÖ÷Êä³ö¹¦ÄÜ¡£ÆôÓÃºó£¬¶¨Ê±Æ÷¿ÉÒÔÊä³öĞÅºÅµ½Ö¸¶¨µÄÒı½Å»òÄ£¿é
+		//é…ç½®å®šæ—¶å™¨çš„ä¸»è¾“å‡ºåŠŸèƒ½ã€‚å¯ç”¨åï¼Œå®šæ—¶å™¨å¯ä»¥è¾“å‡ºä¿¡å·åˆ°æŒ‡å®šçš„å¼•è„šæˆ–æ¨¡å—
     timer_primary_output_config(TIMER0, ENABLE);
     timer_enable(TIMER0);
 
-    llc_pwm_set_duty(s_cfg.duty); /* Èç¹ûÄã×ß 50% ¹Ì¶¨£¬ÕâÀïÖ±½ÓÉè 0.5f ¼´¿É */
+    llc_pwm_set_duty(s_cfg.duty); /* å¦‚æœä½ èµ° 50% å›ºå®šï¼Œè¿™é‡Œç›´æ¥è®¾ 0.5f å³å¯ */
 }
 
-/* 	ÆµÂÊÔÚÏß¸üĞÂ£ºÍ¬Ê±¸üĞÂ ARR ºÍ CCR£¬±£³ÖÕ¼¿Õ±È ,ARR£¨Auto-Reload Register£¬×Ô¶¯ÖØ×°ÔØ¼Ä´æÆ÷£©
-		CCR£¨Capture/Compare Register£¬²¶»ñ/±È½Ï¼Ä´æÆ÷£©*/
-//¸Ãº¯ÊıµÄ×÷ÓÃÊÇ½«Ò»¸ö¸¡µãÊı±íÊ¾µÄÕ¼¿Õ±È£¨ d £©×ª»»ÎªÒ»¸ö16Î»ÎŞ·ûºÅÕûÊı£¨ uint16_t £©£¬ÓÃÓÚÅäÖÃPWM£¨Âö¿íµ÷ÖÆ£©µÄCCR£¨²¶»ñ/±È½Ï¼Ä´æÆ÷£©Öµ¡£
+/* 	é¢‘ç‡åœ¨çº¿æ›´æ–°ï¼šåŒæ—¶æ›´æ–° ARR å’Œ CCRï¼Œä¿æŒå ç©ºæ¯” ,ARRï¼ˆAuto-Reload Registerï¼Œè‡ªåŠ¨é‡è£…è½½å¯„å­˜å™¨ï¼‰
+		CCRï¼ˆCapture/Compare Registerï¼Œæ•è·/æ¯”è¾ƒå¯„å­˜å™¨ï¼‰*/
+//è¯¥å‡½æ•°çš„ä½œç”¨æ˜¯å°†ä¸€ä¸ªæµ®ç‚¹æ•°è¡¨ç¤ºçš„å ç©ºæ¯”ï¼ˆ d ï¼‰è½¬æ¢ä¸ºä¸€ä¸ª16ä½æ— ç¬¦å·æ•´æ•°ï¼ˆ uint16_t ï¼‰ï¼Œç”¨äºé…ç½®PWMï¼ˆè„‰å®½è°ƒåˆ¶ï¼‰çš„CCRï¼ˆæ•è·/æ¯”è¾ƒå¯„å­˜å™¨ï¼‰å€¼ã€‚
 static inline uint16_t duty_to_ccr(float d)
 { 
 	d=clampf(d,0.0f,0.99f); 
@@ -176,7 +200,7 @@ void llc_pwm_outputs_enable(bool en)
 }
 
 void llc_pwm_break(bool en){
-    timer_primary_output_config(TIMER0, en ? DISABLE : ENABLE);  // en=1 Ïàµ±ÓÚ¡°É²Í£¡±
+    timer_primary_output_config(TIMER0, en ? DISABLE : ENABLE);  // en=1 ç›¸å½“äºâ€œåˆ¹åœâ€
 }
 void llc_pwm_set_freq(uint32_t f_hz)
 { 
@@ -188,17 +212,17 @@ void llc_pwm_set_freq(uint32_t f_hz)
 	s_period=(tclk/f_hz)-1U;
 	TIMER_CAR(TIMER0)=s_period; 
 	
-	/* ±£³Öµ±Ç°Õ¼¿Õ±È£¨»ò¹Ì¶¨ 50%£ºÖ±½ÓÓÃ s_period/2£© */
+	/* ä¿æŒå½“å‰å ç©ºæ¯”ï¼ˆæˆ–å›ºå®š 50%ï¼šç›´æ¥ç”¨ s_period/2ï¼‰ */
 	TIMER_CH0CV(TIMER0) = duty_to_ccr(s_cfg.duty);
-	/* Èô LLC_PWM_CH ²»ÊÇ CH0£¬Çë¸Ä³É¶ÔÓ¦µÄ TIMER_CHxCV ºê */
+	/* è‹¥ LLC_PWM_CH ä¸æ˜¯ CH0ï¼Œè¯·æ”¹æˆå¯¹åº”çš„ TIMER_CHxCV å® */
 }
 
 uint32_t llc_pwm_get_period_ns(void)
 {
-    uint32_t tclk = timer0_clk_hz();                 // TIM ÄÚ²¿Ê±ÖÓ Hz
-    uint32_t arr  = TIMER_CAR(TIMER0);               // µ±Ç° ARR
-    // ÄãµÄ set_freq ÓÃµÄÊÇ±ßÑØ¼ÆÊı£ºf = tclk/(ARR+1)
-    // ÖÜÆÚ(ns) = 1e9 * (ARR+1) / tclk
+    uint32_t tclk = timer0_clk_hz();                 // TIM å†…éƒ¨æ—¶é’Ÿ Hz
+    uint32_t arr  = TIMER_CAR(TIMER0);               // å½“å‰ ARR
+    // ä½ çš„ set_freq ç”¨çš„æ˜¯è¾¹æ²¿è®¡æ•°ï¼šf = tclk/(ARR+1)
+    // å‘¨æœŸ(ns) = 1e9 * (ARR+1) / tclk
     if (tclk == 0U) 
 			return 0U;
     uint64_t ns = (1000000000ULL * (uint64_t)(arr + 1U)) / (uint64_t)tclk;
@@ -207,5 +231,5 @@ uint32_t llc_pwm_get_period_ns(void)
 
 uint32_t llc_pwm_get_deadtime_ns(void)
 {
-    return s_cfg.deadtime_ns; // Ö±½Ó»Ø´«ÄãÅäÖÃ½øÀ´µÄËÀÇø£¨ns£©
+    return s_cfg.deadtime_ns; // ç›´æ¥å›ä¼ ä½ é…ç½®è¿›æ¥çš„æ­»åŒºï¼ˆnsï¼‰
 }


### PR DESCRIPTION
## Summary
- use TIMER0 channel 2 compare to generate an ADC trigger at the PWM midpoint
- update ADC DMA setup and documentation to consume the new trigger source
- switch application init to request the TIMER0 CH2 trigger when starting ADC captures

## Testing
- not run (hardware-dependent project)


------
https://chatgpt.com/codex/tasks/task_e_68f1aacb27b4832c85ca9168b60ea0f1